### PR TITLE
Sec-WebSocket-Key is 16-byte value

### DIFF
--- a/src/web_socket_client/WebSocketClient.brs
+++ b/src/web_socket_client/WebSocketClient.brs
@@ -610,12 +610,13 @@ function WebSocketClient() as object
         end if
     end function
 
-    ' Generate a 20 character [A-Za-z0-9] random string and base64 encode it
+    ' Generate a 16 character [A-Za-z0-9] random string and base64 encode it
+    ' @link https://tools.ietf.org/html/rfc6455#section-4.1
     ' @param self WebSocketClient
-    ' @return string random 20 character base64 encoded string
+    ' @return string random 16 character base64 encoded string
     ws._generate_sec_ws_key = function () as string
         sec_ws_key = ""
-        for char_index = 0 to 19
+        for char_index = 0 to 15
             char = m._CHARS[rnd(m._CHARS.count()) - 1]
             if rnd(2) = 1
                 char = ucase(char)


### PR DESCRIPTION
The request MUST include a header field with the name |Sec-WebSocket-Key|. The value of this header field MUST be a nonce consisting of a randomly selected 16-byte value that has been base64-encoded (see Section 4 of [RFC4648]). The nonce MUST be selected randomly for each connection.