### PR TITLE
Support TLS 1.2 TLS_RSA_WITH_AES_256_CBC_SHA256

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,9 +30,9 @@ Example:
 ```brightscript
 function init() as void
     m.ws = createObject("roSGNode", "WebSocketClient")
-    m.ws.observeField("on_open", "on_open")
-    m.ws.observeField("on_message", "on_message")
-    m.ws.open = "ws://echo.websocket.org/"
+    m.ws.observeField("on_websocket_open", "on_open")
+    m.ws.observeField("on_websocket_message", "on_message")
+    m.ws.open = "wss://echo.websocket.org/"
 end function
 
 function on_open(event as object) as void

--- a/src/WebSocketClient.xml
+++ b/src/WebSocketClient.xml
@@ -10,20 +10,38 @@
 
     <interface>
         <!-- Fields -->
-        <field id="on_open" type="assocarray" alwaysNotify="true" />
-        <field id="on_close" type="string" alwaysNotify="true" />
-        <field id="on_message" type="assocarray" alwaysNotify="true" />
-        <field id="on_error" type="assocarray" alwaysNotify="true" />
+        <field id="on_websocket_open" type="assocarray" alwaysNotify="true" />
+        <field id="on_websocket_close" type="assocarray" alwaysNotify="true" />
+        <field id="on_websocket_message" type="assocarray" alwaysNotify="true" />
+        <field id="on_websocket_error" type="assocarray" alwaysNotify="true" />
         <field id="STATE_CONNECTING" type="integer" />
         <field id="STATE_OPEN" type="integer" />
         <field id="STATE_CLOSING" type="integer" />
         <field id="STATE_CLOSED" type="integer" />
-        <field id="ready_state" type="integer" alwaysNotify="true" />
+        <field id="websocket_ready_state" type="integer" alwaysNotify="true" />
         <field id="protocols" type="array" alwaysNotify="true" />
         <field id="headers" type="array" alwaysNotify="true" />
         <field id="secure" type="boolean" alwaysNotify="true" />
         <field id="buffer_size" type="integer" alwaysNotify="true" />
         <field id="log_level" type="string" alwaysNotify="true" />
+
+        <!-- connect_timeout in seconds is deadline for the Web-Socket hadnshake  -->
+        <field id="connect_timeout" type="integer" value="10"/>
+        <!-- close_timeout in seconds is deadline for greaceful Web-Socket close.
+             If Web-Socket close messages are not exchanged within the close_timeout,
+             the TCP socked is closed and the Web-Socket is considered closed. -->
+        <field id="close_timeout" type="integer" value="5"/>
+        <!-- ping_interval in seconds. On 0 ping-pong is disabled,
+             otherwise automatic ping message will be sent on the specified interval.-->
+        <field id="ping_interval" type="integer" value="0"/>
+        <!-- pong_max_missed - count of missed PONG responses before closing the Web-Socket -->
+        <field id="pong_max_missed" type="integer" value="3"/>
+        <!-- pong_timeout in seconds is the deadline to receive the pong response
+             from the server if ping-pong is enabled -->
+        <field id="pong_timeout" type="integer" value="5"/>
+        <!-- Configure server for RSA encryption of the pre-master secret -->
+        <field id="rsa_service_info" type="assocarray" />
+
         <!-- Functions -->
         <field id="open" type="string" alwaysNotify="true" />
         <field id="send" type="array" alwaysNotify="true" />
@@ -32,7 +50,7 @@
 
     <script type="text/brightscript" uri="pkg:/components/web_socket_client/WebSocketClient.brs" />
     <script type="text/brightscript" uri="pkg:/components/web_socket_client/WebSocketClientTask.brs" />
-    <script type="text/brightscript" uri="pkg:/components/web_socket_client/Logger.brs" />
     <script type="text/brightscript" uri="pkg:/components/web_socket_client/ByteUtil.brs" />
+    <script type="text/brightscript" uri="pkg:/components/web_socket_client/Logger.brs" />
     <script type="text/brightscript" uri="pkg:/components/web_socket_client/TlsUtil.brs" />
 </component>

--- a/src/web_socket_client/ByteUtil.brs
+++ b/src/web_socket_client/ByteUtil.brs
@@ -144,3 +144,13 @@ end function
 function xor(a as integer, b as integer) as integer
     return (a or b) and not (a and b)
 end function
+
+function bit_at_position(a as integer, position as integer) as boolean
+    position_num = 1
+    position_num <<= position - 1
+    if (a and position_num) > 0
+        return true
+    else
+        return false
+    end if
+end function

--- a/src/web_socket_client/TlsUtil.brs
+++ b/src/web_socket_client/TlsUtil.brs
@@ -6,11 +6,17 @@
 ' Follows RFC 5246
 
 ' TlsUtil object
-' Requires pkg:/components/web_socket_client/Logger.brs
-' Requires pkg:/components/web_socket_client/ByteUtil.brs
-' @param socket roStreamSocket async TCP socket
-function TlsUtil(socket = invalid as object) as object
+' Requires pkg:/components/WebSocket/ByteUtil.brs
+
+function TlsUtil() as object
     tls_util = {}
+
+    ' Configure server for RSA encryption
+    tls_util._rsa_service_info = {
+        url: "",
+        headers: {},
+    }
+
     ' Constants
     tls_util.STATE_DISCONNECTED = 0
     tls_util.STATE_CONNECTING = 1
@@ -18,7 +24,7 @@ function TlsUtil(socket = invalid as object) as object
     tls_util._BUFFER_SIZE = cint(1024 * 1024 * 1)
     tls_util._TLS_VERSION = [3, 3]
     ' TLS Constants
-    tls_util._TLS_FRAGMENT_MAX_LENGTH = 2^14
+    tls_util._TLS_FRAGMENT_MAX_LENGTH = 2 ^ 14
     tls_util._HANDSHAKE_TYPE = {
         HELLO_REQUEST: 0,
         CLIENT_HELLO: 1,
@@ -43,7 +49,7 @@ function TlsUtil(socket = invalid as object) as object
         EC_POINT_FORMATS: 11
     }
     tls_util._ALERT_LEVEL = {
-        WARNING: 1
+        WARNING: 1,
         FATAL: 2
     }
     tls_util._ALERT_TYPE = {
@@ -66,255 +72,351 @@ function TlsUtil(socket = invalid as object) as object
         UNCOMPRESSED: 0
     }
     ' Variables
+    tls_util._logger = Logger("TlsUtil")
     tls_util._data = createObject("roByteArray")
+    tls_util._date_time_object = createObject("roDateTime")
     tls_util._data[tls_util._BUFFER_SIZE] = 0
     tls_util._data_size = 0
-    tls_util.ready_state = tls_util.STATE_DISCONNECTED
-    tls_util._socket = socket
+    tls_util.websocket_ready_state = tls_util.STATE_DISCONNECTED
     tls_util._hostname = invalid
+    tls_util._client_hello_random = invalid
+    tls_util._server_hello_random = invalid
     tls_util._cipher_suite = invalid
-    tls_util._handshake_buffer = createObject("roByteArray")
     tls_util._supported_extensions = []
+    tls_util._server_extensions = [] ' Extensions negotiated by server
     tls_util._handshake_start_time = 0
     tls_util._certificates = []
     tls_util._server_public_key = invalid
-    
+    tls_util._bypass_tls = false
+    tls_util._premaster_secret = invalid
+    tls_util._master_secret = invalid
+    tls_util._client_keys = invalid
+
+    tls_util.session_keys = {}
+    tls_util.client_seq_num = 0&
+    tls_util.server_seq_num = 0&
+
+    ' TLS Constants
+    tls_util.TLS1_2_VERSION = &h0303
+    tls_util.CIPHER_SUITE = &h003D ' TLS_RSA_WITH_AES_256_CBC_SHA256
+    ' tls_util._NL = chr(13) + chr(10)
+
+    tls_util.two_chars_regex = CreateObject("roRegex", "([a-z0-9]{2})", "i")
+    tls_util._connect_timeout_seconds = 30
+
     ' Decode TLS bytes
     ' This function buffers data if it does not have enough bytes to decode
-    ' @param self TlsUtil object referring to the TlsObject to operate on,
-    '                     usually itself
     ' @param input roByteArray
     ' @param size integer size of usable data in the input array starting from
     '                     index 0
     ' @return roByteArray of decoded data. The returned array may have a count
     '         of zero. May return invalid on error
-    tls_util.read = function (self as object, input as object, size as integer) as object
-        if self.ready_state = self.STATE_DISCONNECTED
-            printl("DEBUG", "TlsUtil: Read failed: state is disconnected")
+    tls_util.read = function(input as object, size as integer) as object
+        if m.websocket_ready_state = m.STATE_DISCONNECTED
+            m._logger.printl(m._logger.DEBUG, "TlsUtil: Read failed: state is disconnected")
             return invalid
         end if
-        if self._has_handshake_timed_out(self)
-            printl("DEBUG", "TlsUtil: Handshake timed out")
+        if m._has_handshake_timed_out()
+            m._logger.printl(m._logger.DEBUG, "TlsUtil: Handshake timed out")
             return invalid
         end if
         decoded_app_data = createObject("roByteArray")
         ' TLS Record Frame
         if size >= 0
             ' Save to buffer
-            for byte_index = self._data_size to self._data_size + size - 1
-                self._data[byte_index] = input[byte_index - self._data_size]
+            for byte_index = m._data_size to m._data_size + size - 1
+                m._data[byte_index] = input[byte_index - m._data_size]
             end for
-            self._data_size += size
+            m._data_size += size
             input = invalid
             ' Wait for frame size
             fragment_start_index = 5
-            if self._data_size < fragment_start_index
+            if m._data_size < fragment_start_index
                 return decoded_app_data
             end if
             ' Record
-            content_type = self._data[0]
-            version_major = self._data[1]
-            version_minor = self._data[2]
-            fragment_length = bytes_to_short(self._data[3], self._data[4])
+            record_type = m._data[0]
+            version_major = m._data[1]
+            version_minor = m._data[2]
+            fragment_length = bytes_to_short(m._data[3], m._data[4])
             ' Check version
-            if self._TLS_VERSION[0] <> version_major or self._TLS_VERSION[1] <> version_minor
-                self._error(self, self._ALERT_TYPE.PROTOCOL_VERSION, "Received a frame with an an unsupported version defined")
+            if m._TLS_VERSION[0] <> version_major or m._TLS_VERSION[1] <> version_minor
+                m._error(m._ALERT_TYPE.PROTOCOL_VERSION, "Received a frame with an an unsupported version defined")
                 return invalid
             end if
             ' Wait for fragment
-            if self._data_size < fragment_start_index + fragment_length
+            if m._data_size < fragment_start_index + fragment_length
                 return decoded_app_data
             end if
             ' Fragment
             fragment = createObject("roByteArray")
             for byte_index = fragment_start_index to fragment_start_index + fragment_length - 1
-                fragment.push(self._data[byte_index])
+                fragment.push(m._data[byte_index])
             end for
-            handled_fragment = self._handle_fragment(self, content_type, fragment)
+
+            handled_fragment = m._handle_fragment(record_type, fragment)
             if handled_fragment = invalid
                 return invalid
             else
                 decoded_app_data.append(handled_fragment)
             end if
             ' Delete fragment from buffer
-            self._data = byte_array_sub(self._data, fragment_start_index + fragment_length, self._data_size - 1)
-            self._data_size = self._data.count()
-            self._data[self._BUFFER_SIZE] = 0
+            m._data = byte_array_sub(m._data, fragment_start_index + fragment_length, m._data_size - 1)
+            m._data_size = m._data.count()
+            m._data[m._BUFFER_SIZE] = 0
         end if
         return decoded_app_data
     end function
-    
+
     ' Check if the handshake has timed out
-    ' @param TlsUtil
     ' @return if the handshake has not completed before a timed out
-    tls_util._has_handshake_timed_out = function (self as object) as boolean
-        return uptime(0) - self._handshake_start_time >= 30 and self._handshake_start_time > -1
+    tls_util._has_handshake_timed_out = function() as boolean
+        return uptime(0) - m._handshake_start_time >= 30 and m._handshake_start_time > -1
     end function
-    
+
     ' Send a fatal alert and optionally log a debug message and set the state to disconnected if fatal
-    ' @param self TlsUtil
     ' @param alert_type integer type
     ' @param message string optional message to log
     ' @param fatal boolean set the alert type to fatal and disconnect
-    tls_util._error = function (self as object, alert_type as integer, message = "" as string, fatal = true as boolean) as void
-        level = self._ALERT_LEVEL.FATAL
+    tls_util._error = sub(alert_type as integer, message = "" as string, fatal = true as boolean) as void
+        level = m._ALERT_LEVEL.FATAL
         if not fatal
-            level = self._ALERT_LEVEL.WARNING
+            level = m._ALERT_LEVEL.WARNING
         end if
-        self._send_alert(self, level, alert_type)
+        m._send_alert(level, alert_type)
         if message <> ""
-            printl("DEBUG", "TlsUtil: Error: " + message)
+            m._logger.printl(m._logger.DEBUG, "TlsUtil: Error: " + message)
         end if
         if fatal
-            self.ready_state = self.STATE_DICONNECTED
+            m.websocket_ready_state = m.STATE_DISCONNECTED
         end if
-    end function
-    
+    end sub
+
     ' Send an alert
-    ' @param self TlsUtil
     ' @param alert_level integer level of alert
     ' @param alert_type integer alert description
-    tls_util._send_alert = function (self as object, alert_level as integer, alert_type as integer)
+    tls_util._send_alert = sub(alert_level as integer, alert_type as integer)
         alert = createObject("roByteArray")
         alert.push(alert_level)
         alert.push(alert_type)
-        self._send_record(self, self._RECORD_TYPE.ALERT, alert)
-    end function
-    
+        m._sendRecord(m._RECORD_TYPE.ALERT, alert)
+    end sub
+
     ' Handle opaque fragment data
-    ' @param self TlsUtil
-    ' @param content_type type of frame
+    ' @param record_type type of frame
     ' @param frame roByteArray frame
     ' @return potentially empty roByteArray or invalid on error. disconnect state is handled on error
-    tls_util._handle_fragment = function (self as object, content_type as integer, fragment as object) as object
-        printl("VERBOSE", "TlsUtil: Received fragment of type " + content_type.toStr() + ": " + fragment.toHexString())
+    tls_util._handle_fragment = function(record_type as integer, fragment as object) as object
+        m._logger.printl(m._logger.VERBOSE, "Received fragment of type " + record_type.toStr() + ": " + m.format_hex_bytes(fragment))
         decoded_app_data = createObject("roByteArray")
         while fragment.count() > 0
             ' Handshake
-            if content_type = self._RECORD_TYPE.HANDSHAKE
+            if record_type = m._RECORD_TYPE.HANDSHAKE
                 fragment_header_size = 4
                 ' Invalid data
                 if fragment.count() < fragment_header_size
-                    self._error_handshake(self)
+                    m._error_handshake()
                     return invalid
-                ' Handle handshake data
+                    ' Handle handshake data
                 else
-                    handshake_type = fragment[0]
-                    length = bytes_to_int24(fragment[1], fragment[2], fragment[3])
-                    if fragment.count() < fragment_header_size + length
-                        self._error_handshake(self)
+                    if m.changeCipherSpecReceived = true
+                        m._logger.printl(m._logger.DEBUG, "Received Server Finished (Encrypted)")
+                        m._logger.printl(m._logger.DEBUG, "TlsClient", "*** TLS 1.2 HANDSHAKE SUCCESSFUL ***")
+                        m._logger.printl(m._logger.DEBUG, "TlsUtil: Received Finished: " + m.format_hex_bytes(fragment))
+                        ' Server has sent Finished message, handshake is complete
+                        m.websocket_ready_state = m.STATE_FINISHED
+                        m._logger.printl(m._logger.DEBUG, "TlsUtil: TLS handshake completed successfully")
+                        m.server_seq_num++ ' CRITICAL: Account for this encrypted record
+                        return decoded_app_data
+                    end if
+
+                    handshake_type = m._readChar(fragment, 0)
+                    handshake_len = m._readInt24(fragment, 1)
+
+                    if fragment.count() < fragment_header_size + handshake_len
+                        m._logger.printl(m._logger.DEBUG, "Incomplete handshake fragment received. Needs to be :" + handshake_len.ToStr() + " but it is: " + fragment.count().ToStr())
                         return invalid
                     end if
-                    handshake_data = createObject("roByteArray")
-                    for byte_index = fragment_header_size to fragment_header_size + length - 1
-                        handshake_data.push(fragment[byte_index])
-                    end for
-                    if not self._handle_handshake(self, handshake_type, handshake_data)
+
+                    ' Only hash the current handshake message, not the entire fragment
+                    current_handshake_msg = fragment.slice(0, fragment_header_size + handshake_len)
+                    m.sha256_update(current_handshake_msg)
+
+                    handshake_data = fragment.slice(fragment_header_size, fragment_header_size + handshake_len)
+
+                    ' Debug: Log handshake message received
+                    #if DEBUG_LOG_WEBSOCKET
+                        print "*** HANDSHAKE RECEIVED: " + m.format_hex_bytes(handshake_data)
+                    #end if
+                    if not m._handle_handshake(handshake_type, handshake_data)
                         return invalid
                     end if
-                    self._handshake_buffer.append(byte_array_sub(fragment, 0, fragment_header_size + length - 1))
-                    fragment = byte_array_sub(fragment, fragment_header_size + length, fragment.count() - 1)
+                    fragment = byte_array_sub(fragment, fragment_header_size + handshake_len, fragment.count() - 1)
                 end if
-            ' App data
-            else if content_type = self._RECORD_TYPE.APPLICATION_DATA
-            ' Alert
-            else if content_type = self._RECORD_TYPE.ALERT
-                if fragment.count() < 2
-                    self._error_handshake(self)
+                ' App data
+            else if record_type = m._RECORD_TYPE.APPLICATION_DATA
+                m._logger.printl(m._logger.DEBUG, "TlsUtil: Received Application Data (Encrypted)")
+                decoded_part = m._readAndDecryptRecord(record_type, fragment)
+                if decoded_part <> invalid
+                    decoded_app_data.append(decoded_part.payload)
+                end if
+                fragment.clear()
+                ' Alert
+            else if record_type = m._RECORD_TYPE.ALERT
+                alert_level = -1
+                alert_description = -1
+                ' After TLS handshake completes, alerts are encrypted
+                if m.websocket_ready_state = m.STATE_FINISHED
+                    m._logger.printl(m._logger.DEBUG, "TlsUtil: Received Alert (Encrypted)")
+                    decoded_part = m._readAndDecryptRecord(record_type, fragment)
+                    if decoded_part <> invalid and decoded_part.payload.count() >= 2
+                        alert_level = decoded_part.payload[0]
+                        alert_description = decoded_part.payload[1]
+                    end if
+                    fragment.clear()
+                else
+                    ' During handshake, alerts are not encrypted
+                    if fragment.count() < 2
+                        m._error_handshake()
+                        return invalid
+                    else
+                        alert_level = fragment[0]
+                        alert_description = fragment[1]
+                        fragment = byte_array_sub(fragment, 2, fragment.count() - 1)
+                    end if
+                end if
+                m._logger.printl(m._logger.DEBUG, "TlsUtil: alert:")
+                m._logger.printl(m._logger.DEBUG, "  level: " + alert_level.toStr())
+                m._logger.printl(m._logger.DEBUG, "  description: " + alert_description.toStr())
+                if alert_level = m._ALERT_LEVEL.FATAL
+                    m._error(m._ALERT_TYPE.CLOSE_NOTIFY, "Received fatal alert", true)
                     return invalid
-                else
-                    alert_level = fragment[0]
-                    alert_description = fragment[1]
-                    printl("DEBUG", "TlsUtil: Received alert:")
-                    printl("DEBUG", "  level: " + alert_level.toStr())
-                    printl("DEBUG", "  description: " + alert_description.toStr())
-                    if alert_level = self._ALERT_LEVEL.FATAL
-                        self._error(self, self._ALERT_TYPE.CLOSE_NOTIFY, "Received fatal alert", true)
-                        return invalid
-                    end if
-                    fragment = byte_array_sub(fragment, 2, fragment.count() - 1)
+                else if alert_level = m._ALERT_LEVEL.WARNING and alert_description = m._ALERT_TYPE.CLOSE_NOTIFY
+                    m._logger.printl(m._logger.DEBUG, "TlsUtil: Received close_notify alert, closing connection")
+                    m.websocket_ready_state = m.STATE_DISCONNECTED
+                    m._socket.close()
                 end if
-            ' Cipher spec
-            else if content_type = self._CHANGE_CIPHER_SPEC
-                
+
+                ' Cipher spec
+            else if record_type = m._RECORD_TYPE.CHANGE_CIPHER_SPEC
+                ' Handle ChangeCipherSpec message
+                m._logger.printl(m._logger.DEBUG, "TlsUtil: Received ChangeCipherSpec")
+                fragment = byte_array_sub(fragment, 1, fragment.count() - 1)
+                m.changeCipherSpecReceived = true
             end if
         end while
         return decoded_app_data
     end function
-    
+
     ' Handle handshake data
-    ' @param self TlsUtil
     ' @param handshake_type integer type of handshake data
     ' @param handshake roByteArray handshake data
     ' @return false on error
-    tls_util._handle_handshake = function (self as object, handshake_type as integer, handshake as object) as boolean
+    tls_util._handle_handshake = function(handshake_type as integer, handshake as object) as boolean
         ' HelloRequest
-        if handshake_type = self._HANDSHAKE_TYPE.HELLO_REQUEST
-            if self.ready_state = self.STATE_DISCONNECTED
-                self.connect(self, self._hostname)
+        if handshake_type = m._HANDSHAKE_TYPE.HELLO_REQUEST
+            ' Only initiate new handshake if we're truly disconnected and not in progress
+            if m.websocket_ready_state = m.STATE_DISCONNECTED
+                m._logger.printl(m._logger.DEBUG, "TlsUtil: Received HelloRequest, initiating new handshake")
+                m.connect(m._hostname)
+            else
+                m._logger.printl(m._logger.DEBUG, "TlsUtil: Ignoring HelloRequest during active handshake (state: " + m.websocket_ready_state.toStr() + ")")
             end if
-        ' ServerHello
-        else if handshake_type = self._HANDSHAKE_TYPE.SERVER_HELLO
+            ' ServerHello
+        else if handshake_type = m._HANDSHAKE_TYPE.SERVER_HELLO
             if handshake.count() < 38
-                self._error_handshake(self)
+                m._error_handshake()
                 return false
             end if
             version_major = handshake[0]
             version_minor = handshake[1]
-            if version_major <> self._tls_version[0] or version_minor <> self._tls_version[1]
-                self._error_handshake(self)
+            if version_major <> m._TLS_VERSION[0] or version_minor <> m._TLS_VERSION[1]
+                m._error_handshake()
                 return false
             end if
-            random_time = bytes_to_int(handshake[2], handshake[3], handshake[4], handshake[5])
-            random = createObject("roByteArray")
-            for byte_index = 6 to 33
-                random.push(handshake[byte_index])
-            end for
+            m.server_random = handshake.slice(2, 34) ' Skip version
             session_id = createObject("roByteArray")
             session_id_length = handshake[34]
             for byte_index = 35 to 34 + session_id_length
-                random.push(handshake[byte_index])
+                session_id.push(handshake[byte_index])
             end for
             cipher_suite = createObject("roByteArray")
             cipher_suite.push(handshake[35 + session_id_length])
             cipher_suite.push(handshake[36 + session_id_length])
-            self._cipher_suite = cipher_suite
-            compression_method = handshake[37 + session_id_length]
-            if compression_method <> self._COMPRESSION_METHODS.NULL
-                self._error_handshake(self)
+            m._cipher_suite = cipher_suite
+            compression_method = m._readChar(handshake, 37 + session_id_length)
+            if compression_method <> m._COMPRESSION_METHODS.NULL
+                m._logger.printl(m._logger.FATAL, "TlsUtil: Unsupported compression method received: " + compression_method.toStr())
+                m._error_handshake()
                 return false
             end if
             extensions = createObject("roByteArray")
             if handshake.count() > 38 + session_id_length
                 extensions_length = bytes_to_short(handshake[38 + session_id_length], handshake[39 + session_id_length])
-                for byte_index = 40 + session_id_length to 39 + session_id_length + extensions_length
+                m._logger.printl(m._logger.DEBUG, "*** SERVERHELLO DEBUG: handshake.count()=" + handshake.count().toStr() + ", session_id_length=" + session_id_length.toStr())
+                m._logger.printl(m._logger.DEBUG, "*** SERVERHELLO DEBUG: extensions_length=" + extensions_length.toStr())
+                m._logger.printl(m._logger.DEBUG, "*** SERVERHELLO DEBUG: extensions start at offset " + (40 + session_id_length).toStr())
+                ' Extract extensions data (skip the 2-byte length field)
+                for byte_index = 40 + session_id_length to 40 + session_id_length + extensions_length - 1
                     extensions.push(handshake[byte_index])
                 end for
+                print "*** SERVERHELLO DEBUG: extracted " + extensions.count().toStr() + " bytes of extensions data"
+                if extensions.count() > 0
+                    print "*** SERVERHELLO DEBUG: extensions hex: " + extensions.toHexString()
+                end if
+            else
+                print "*** SERVERHELLO DEBUG: No extensions found (handshake too short)"
             end if
             extension_types = []
+            m._server_extensions = [] ' Track server extensions for EMS negotiation
             if extensions.count() > 0
                 extension_index = 0
                 while extension_index < extensions.count()
                     if extensions.count() - extension_index < 4
-                        self._error_handshake(self)
+                        m._error_handshake()
                         return false
                     end if
                     extension_type = bytes_to_short(extensions[extension_index], extensions[extension_index + 1])
                     extension_length = bytes_to_short(extensions[extension_index + 2], extensions[extension_index + 3])
                     extension_index += 4 + extension_length
                     extension_types.push(extension_type)
+                    m._server_extensions.push(extension_type) ' Store for later use
                 end while
+            end if
+
+            ' Log server extensions for debugging
+            if m._server_extensions.count() > 0
+                ext_list = []
+                for each ext in m._server_extensions
+                    extItem = "0x" + StrI(ext, 16)
+                    ext_list.Push(extItem)
+                end for
+                m._logger.printl(m._logger.DEBUG, "TlsUtil: Server negotiated extensions: [" + ext_list.join(", ") + "]")
+                print "*** SERVER EXTENSIONS: [" + ext_list.join(", ") + "]"
+
+                ' Check specifically for Extended Master Secret
+                has_ems = false
+                for each ext_type in m._server_extensions
+                    if ext_type = &h0017
+                        has_ems = true
+                        exit for
+                    end if
+                end for
+                print "*** EXTENDED MASTER SECRET NEGOTIATED: " + has_ems.toStr()
+            else
+                print "*** SERVER EXTENSIONS: NONE"
+                print "*** EXTENDED MASTER SECRET NEGOTIATED: false"
             end if
             for each extension_type in extension_types
                 ' Check if extension was requested
                 was_extension_requested = false
-                for each supported_extension in self._supported_extensions
+                for each supported_extension in m._supported_extensions
                     if supported_extension = extension_type
                         was_extension_requested = true
                     end if
                 end for
                 if not was_extension_requested
-                    self._error(self, self._ALERT_TYPE.UNSUPPORTED_EXTENSION, "Received invalid extension data", true)
+                    m._error(m._ALERT_TYPE.UNSUPPORTED_EXTENSION, "Received invalid extension data", true)
                     return false
                 end if
                 ' Check if extension has been defined more than once
@@ -323,31 +425,33 @@ function TlsUtil(socket = invalid as object) as object
                     if extension_type = extension_type_loop
                         extension_definitions++
                         if extension_definitions > 1
-                            self._error(self, self._ALERT_TYPE.UNSUPPORTED_EXTENSION, "Received invalid extension data", true)
+                            m._error(m._ALERT_TYPE.UNSUPPORTED_EXTENSION, "Received invalid extension data", true)
                             return false
                         end if
                     end if
                 end for
             end for
-            printl("DEBUG", "TlsUtil: Received ServerHello:")
-            printl("DEBUG", "  cipher suite: " + cipher_suite.toHexString())
-        ' Certificate
-        else if handshake_type = self._HANDSHAKE_TYPE.CERTIFICATE
+            m._logger.printl(m._logger.DEBUG, "TlsUtil: Received ServerHello:")
+
+            m._logger.printl(m._logger.DEBUG, "  cipher suite: " + cipher_suite.toHexString())
+
+            ' Certificate
+        else if handshake_type = m._HANDSHAKE_TYPE.CERTIFICATE
             certificate_list = []
             if handshake.count() < 3
-                self._error_handshake(self)
+                m._error_handshake()
                 return false
             end if
             certificate_list_length = bytes_to_int24(handshake[0], handshake[1], handshake[2])
-            if handshake.count() < 3 + certificate_list_length
-                self._error_handshake(self)
+            if handshake.count() < 2 + certificate_list_length
+                m._error_handshake()
                 return false
             end if
             certificate_index = 3
             while certificate_index + 1 < handshake.count()
                 certificate_size = bytes_to_int24(handshake[certificate_index], handshake[certificate_index + 1], handshake[certificate_index + 2])
                 if handshake.count() < certificate_index + certificate_size
-                    self._error_handshake(self)
+                    m._error_handshake()
                     return false
                 end if
                 certificate = createObject("roByteArray")
@@ -357,306 +461,651 @@ function TlsUtil(socket = invalid as object) as object
                 certificate_list.push(certificate)
                 certificate_index += 3 + certificate_size
             end while
-            self._certificates = certificate_list
-            printl("DEBUG", "TlsUtil: Received Certificate: " + certificate_list.count().toStr() + " certificates")
-        ' ServerKeyExchange
-        else if handshake_type = self._HANDSHAKE_TYPE.SERVER_KEY_EXCHANGE
-            printl("DEBUG", "TlsUtil: Received ServerKeyExchange: " + handshake.toHexString())
-            self._error_handshake(self)
+            m._certificates = certificate_list
+            m._logger.printl(m._logger.DEBUG, "TlsUtil: Received Certificate: " + certificate_list.count().toStr() + " certificates")
+            ' ServerKeyExchange
+        else if handshake_type = m._HANDSHAKE_TYPE.SERVER_KEY_EXCHANGE
+            m._logger.printl(m._logger.DEBUG, "TlsUtil: Received ServerKeyExchange: " + handshake.toHexString())
+            m._error_handshake()
             return false
-        ' Certificate Request
-        else if handshake_type = self._HANDSHAKE_TYPE.CERTIFICATE_REQUEST
-            printl("DEBUG", "TlsUtil: Received CertificateRequest: " + handshake.toHexString())
-            self._error_handshake(self)
+            ' Certificate Request
+        else if handshake_type = m._HANDSHAKE_TYPE.CERTIFICATE_REQUEST
+            m._logger.printl(m._logger.DEBUG, "TlsUtil: Received CertificateRequest: " + handshake.toHexString())
+            m._error_handshake()
             return false
-        ' ServerHelloDone
-        else if handshake_type = self._HANDSHAKE_TYPE.SERVER_HELLO_DONE
-            self._handshake_start_time = -1
-            ' Verify certificate
-            if not self._verify_certificate(self)
-                self._error(self, self._ALERT_TYPE.BAD_CERTIFICATE, "Server certificate failed to verify", true)
+            ' ServerHelloDone
+        else if handshake_type = m._HANDSHAKE_TYPE.SERVER_HELLO_DONE
+            m._handshake_start_time = -1
+            m._logger.printl(m._logger.DEBUG, "TlsUtil: Received ServerHelloDone")
+            if not m._sendClientKeyExchange()
                 return false
             end if
-            printl("DEBUG", "TlsUtil: Received ServerHelloDone")
-            self._send_client_key_exchange(self)
-            self._send_client_finish(self)
-        ' Finished
-        else if handshake_type = self._HANDSHAKE_TYPE.FINISHED
-            printl("DEBUG", "TlsUtil: Received Finished: " + handshake.toHexString())
+            m._deriveKeys()
+            if not m._sendChangeCipherSpecAndFinished()
+                m._logger.printl(m._logger.FATAL, "TlsUtil: _sendChangeCipherSpecAndFinished failed")
+                return false
+            end if
+            ' Finished
+        else if handshake_type = m._HANDSHAKE_TYPE.FINISHED
+            m._logger.printl(m._logger.DEBUG, "TlsUtil: Received Finished: " + handshake.toHexString())
+            ' Server has sent Finished message, handshake is complete
+            m.websocket_ready_state = m.STATE_FINISHED
+            m._logger.printl(m._logger.DEBUG, "TlsUtil: TLS handshake completed successfully")
         end if
         return true
     end function
-    
-    ' Send the client finish message
-    ' @param self TlsUtil
-    tls_util._send_client_finish = function (self as object) as void
-        
-    end function
-    
-    ' Send the client key exchange handshake message
-    ' @param self TlsUtil
-    tls_util._send_client_key_exchange = function (self as object) as void
-        printl("EXTRA", "TlsUtil: Generating client key exchange message")
-        ' TLS_RSA_WITH_AES_128_GCM_SHA256 || TLS_RSA_WITH_AES_256_GCM_SHA384 || TLS_RSA_WITH_AES_128_CBC_SHA256 || TLS_RSA_WITH_AES_256_CBC_SHA256
-        if byte_array_equals(byte_array([&h00, &h9c]), self._cipher_suite) or byte_array_equals(byte_array([&h00, &h9d]), self._cipher_suite) or byte_array_equals(byte_array([&h00, &h3c]), self._cipher_suite) or byte_array_equals(byte_array([&h00, &h3d]), self._cipher_suite)
-            printl("DEBUG", "TlsUtil: Generating RSA premaster secret")
-            secret = createObject("roByteArray")
-            secret.append(byte_array(self._TLS_VERSION))
-            for byte_index = 0 to 45
-                secret.push(rnd(256) - 1)
-            end for
-            encrypted_secret = rsa_encrypt(self._server_public_key, secret)
-        else
-            printl("FATAL", "TlsUtil: Unhandled cipher suite: " + self._cipher_suite.toStr())
+
+    tls_util._deriveKeys = sub() as void
+        if m.master_secret <> invalid
+            return
         end if
-    end function
-    
-    ' Verify a certificate
-    ' @param self TlsUtil
-    tls_util._verify_certificate = function (self as object) as boolean
-        ' TODO validate the certificate
-        self._server_public_key = createObject("roByteArray")
-        print self._certificates[0]
-        print "--"
-        print self._certificates[1]
-        return true
-    end function
-    
+        m._logger.printl(m._logger.DEBUG, "--- Deriving Keys ---")
+
+        ' Master Secret
+        master_seed = createObject("roByteArray")
+        master_seed.append(m.client_random)
+        master_seed.append(m.server_random)
+        m.master_secret = m.prf_sha256(m.pre_master_secret, "master secret", master_seed, 48)
+        m._logger.printl(m._logger.DEBUG, "Master Secret: " + m.format_hex_bytes(m.master_secret))
+
+        ' Session Keys
+        key_expansion_seed = m.server_random
+        key_expansion_seed.append(m.client_random)
+
+        mac_key_size = 32
+        enc_key_size = 32
+        key_material_len = (mac_key_size + enc_key_size) * 2
+
+        key_material = m.prf_sha256(m.master_secret, "key expansion", key_expansion_seed, key_material_len)
+
+        offset = 0
+        m.session_keys.client_write_MAC_key = key_material.slice(offset, offset + mac_key_size) : offset += mac_key_size
+        m.session_keys.server_write_MAC_key = key_material.slice(offset, offset + mac_key_size) : offset += mac_key_size
+        m.session_keys.client_write_key = key_material.slice(offset, offset + enc_key_size) : offset += enc_key_size
+        m.session_keys.server_write_key = key_material.slice(offset, offset + enc_key_size)
+
+        m._logger.printl(m._logger.DEBUG, "Client Write Key: " + m.format_hex_bytes(m.session_keys.client_write_key))
+        m._logger.printl(m._logger.DEBUG, "Client MAC Key: " + m.format_hex_bytes(m.session_keys.client_write_MAC_key))
+    end sub
+
+
     ' Set the ready state to disconnected and send a fatal alert
-    ' @param self TlsUtil
-    tls_util._error_handshake = function (self as object) as void
-        self._error(self, self._ALERT_TYPE.HANDSHAKE_FAILURE, "Received invalid handshake data", true)
-    end function
-    
+    tls_util._error_handshake = sub() as void
+        m._error(m._ALERT_TYPE.HANDSHAKE_FAILURE, "Received invalid handshake data", true)
+    end sub
+
     ' Set the internal socket used for sending
-    ' @param self TlsUtil object
     ' @param socket roStreamSocket async TCP socket
-    tls_util.set_socket = function (self as object, socket as object) as void
-        self._socket = socket
-    end function
-    
+    tls_util.set_socket = sub(socket as object) as void
+        m._socket = socket
+    end sub
+
+    tls_util.set_rsa_service_info = sub(service_info as object) as void
+        m._rsa_service_info = service_info
+    end sub
+
+    tls_util.set_connect_timeout_seconds = sub(connect_timeout_seconds as dynamic)
+        m._connect_timeout_seconds = connect_timeout_seconds
+    end sub
+
     ' Start the TLS handshake with a ClientHello
     ' Should only be called if the client socket is a new connection
     ' @param hostname string hostname
-    ' @param self TlsUtil object
-    tls_util.connect = function (self as object, hostname as string) as void
-        self._hostname = hostname
-        self._cipher_suite = invalid
-        self._handshake_buffer.clear()
-        self._supported_extensions.clear()
-        self._handshake_start_time = uptime(0)
-        self._certificates.clear()
-        self.ready_state = self.STATE_CONNECTING
-        handshake = createObject("roByteArray")
-        ' Body - ClientHello
-        client_hello = createObject("roByteArray")
-        ' Protocol version
-        client_hello.append(byte_array([3, 3])) ' TLS 1.2
-        ' Random
-        client_hello.append(self._Random())
-        ' Session id
-        client_hello.push(0) ' Length
-        ' Ciphersuites
-        ' https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28default.29
-        ciphersuites = createObject("roByteArray")
-        ' TODO implement ecdhe ecdsa and chacha20
-        'ciphersuites.append(byte_array([&hc0, &h2c])) ' TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-        'ciphersuites.append(byte_array([&hc0, &h30])) ' TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-        'ciphersuites.append(byte_array([&hcc, &h14])) ' TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-        'ciphersuites.append(byte_array([&hcc, &h13])) ' TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
-        'ciphersuites.append(byte_array([&hc0, &h2b])) ' TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-        'ciphersuites.append(byte_array([&hc0, &h2f])) ' TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        'ciphersuites.append(byte_array([&hc0, &h24])) ' TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
-        'ciphersuites.append(byte_array([&hc0, &h28])) ' TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
-        'ciphersuites.append(byte_array([&hc0, &h23])) ' TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-        'ciphersuites.append(byte_array([&hc0, &h27])) ' TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-        'ciphersuites.append(byte_array([&hc0, &h28])) ' TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
-        'ciphersuites.append(byte_array([&hc0, &h24])) ' TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
-        'ciphersuites.append(byte_array([&h00, &h67])) ' TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
-        'ciphersuites.append(byte_array([&h00, &h6b])) ' TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
-        ciphersuites.append(byte_array([&h00, &h9c])) ' TLS_RSA_WITH_AES_128_GCM_SHA256
-        ciphersuites.append(byte_array([&h00, &h9d])) ' TLS_RSA_WITH_AES_256_GCM_SHA384
-        ciphersuites.append(byte_array([&h00, &h3c])) ' TLS_RSA_WITH_AES_128_CBC_SHA256
-        ciphersuites.append(byte_array([&h00, &h3d])) ' TLS_RSA_WITH_AES_256_CBC_SHA256
-        client_hello.append(short_to_bytes(ciphersuites.count()))
-        client_hello.append(ciphersuites)
-        ' Compression method
-        compression_methods = createObject("roByteArray")
-        compression_methods.push(self._COMPRESSION_METHODS.NULL) ' Null
-        client_hello.push(compression_methods.count())
-        client_hello.append(compression_methods)
-        ' Extensions
-        extensions = createObject("roByteArray")
-        extensions.append(self._generate_sni_extension(self, hostname))
-        extensions.append(self._generate_supported_groups_extension(self))
-        extensions.append(self._generate_ec_point_formats_extension(self))
-        client_hello.append(short_to_bytes(extensions.count()))
-        client_hello.append(extensions)
-        ' Type
-        handshake.push(self._HANDSHAKE_TYPE.CLIENT_HELLO)
-        ' Length
-        handshake.append(int24_to_bytes(client_hello.count()))
-        ' Body
-        handshake.append(client_hello)
-        sent = self._send_handshake(self, handshake)
+    tls_util.connect = sub(hostname as string) as void
+        m._hostname = hostname
+        m._cipher_suite = invalid
+        m._supported_extensions.clear()
+        m._handshake_start_time = uptime(0)
+        m._certificates.clear()
+        m.websocket_ready_state = m.STATE_CONNECTING
+        m._sendClientHello()
+    end sub
+
+    ' Send data through the TLS tunnel over the socket
+    ' @param payload roByteArray data to send
+    ' @return bytes of payload sent. -1 on error
+    tls_util.send = function(payload as object) as integer
+        if m._sendEncryptedRecord(m._RECORD_TYPE.APPLICATION_DATA, payload)
+            m._logger.printl(m._logger.DEBUG, "Sent len:" + payload.count().toStr() + ", string: " + payload.toAsciiString())
+            return payload.count()
+        else
+            m._logger.printl(m._logger.FATAL, "ERROR sending len:" + payload.count().toStr() + ", string: " + payload.toAsciiString())
+            return -1
+        end if
     end function
-    
-    ' Generate a ec point formats extension
-    ' @param self TlsUtil
-    ' @return roByteArray
-    tls_util._generate_ec_point_formats_extension = function (self as object) as object
-        extension = createObject("roByteArray")
-        ' Type
-        extension.append(short_to_bytes(self._EXTENSION_TYPE.EC_POINT_FORMATS))
-        self._supported_extensions.push(self._EXTENSION_TYPE.EC_POINT_FORMATS)
-        ' ec point formats
-        ec_point_formats = createObject("roByteArray")
-        formats = createObject("roByteArray")
-        formats.push(self._EC_POINT_FORMATS.UNCOMPRESSED)
-        ec_point_formats.push(formats.count())
-        ec_point_formats.append(formats)
-        extension.append(short_to_bytes(ec_point_formats.count()))
-        extension.append(ec_point_formats)
-        return extension
+
+    ' Send string through the TLS tunnel over the socket
+    ' @return bytes of payload sent
+    tls_util.send_str = function(payload as string) as integer
+        ba = createObject("roByteArray")
+        ba.fromAsciiString(payload)
+        return m.send(ba)
     end function
-    
-    ' Generate a supported groups extension
-    ' @param self TlsUtil
-    ' @return roByteArray
-    tls_util._generate_supported_groups_extension = function (self as object) as object
-        extension = createObject("roByteArray")
-        ' Type
-        extension.append(short_to_bytes(self._EXTENSION_TYPE.SUPPORTED_GROUPS))
-        self._supported_extensions.push(self._EXTENSION_TYPE.SUPPORTED_GROUPS)
-        ' Supported groups
-        supported_groups = createObject("roByteArray")
-        groups = createObject("roByteArray")
-        for each supported_group in self._SUPPORTED_GROUPS
-            groups.append(short_to_bytes(self._SUPPORTED_GROUPS[supported_group]))
-        end for
-        supported_groups.append(short_to_bytes(groups.count()))
-        supported_groups.append(groups)
-        extension.append(short_to_bytes(supported_groups.count()))
-        extension.append(supported_groups)
-        return extension
-    end function
-    
-    ' Send handshake data
-    ' Appends payload to handshake buffer
-    ' @param self TlsUtil
-    ' @param payload roByteArray handshake data
-    tls_util._send_handshake = function (self as object, payload as object) as integer
-        self._handshake_buffer.append(payload)
-        return self._send_record(self, self._RECORD_TYPE.HANDSHAKE, payload)
-    end function
-    
-    ' Generate a Server Name Indication (SNI) extension based on a hostname
-    ' @param self TlsUtil
-    ' @param hostname string hostname
-    ' @return roByteArray
-    tls_util._generate_sni_extension = function (self as object, hostname as string) as object
-        extension = createObject("roByteArray")
-        ' Type
-        extension.append(short_to_bytes(self._EXTENSION_TYPE.SERVER_NAME))
-        self._supported_extensions.push(self._EXTENSION_TYPE.SERVER_NAME)
-        ' Server Name Indication
-        sni = createObject("roByteArray")
-        name_list = createObject("roByteArray")
-        name_list.push(0) ' Type
-        hostname_ba = createObject("roByteArray")
-        hostname_ba.fromAsciiString(hostname)
-        name_list.append(short_to_bytes(hostname_ba.count()))
-        name_list.append(hostname_ba)
-        sni.append(short_to_bytes(name_list.count()))
-        sni.append(name_list)
-        extension.append(short_to_bytes(sni.count()))
-        extension.append(sni)
-        return extension
-    end function
-    
+
+    ' Set internal buffer size
+    ' @param size integer
+    tls_util.set_buffer_size = sub(size as integer) as void
+        if m.websocket_ready_state <> m.STATE_DISCONNECTED
+            m._logger.printl(m._logger.WARN, "TlsUtil: Cannot set buffer size while connection is open")
+            return
+        end if
+        m._BUFFER_SIZE = size
+    end sub
+
+    ' Set the log level
+    tls_util.set_log_level_int = sub(level_int as integer) as void
+        m._logger.log_level = level_int
+    end sub
+
     ' Returns a roByteArray that conforms to the Random struct used RFC 5246
-    tls_util._Random = function () as object
+    tls_util.RandomByteArray = function(length as integer) as object
         random = createObject("roByteArray")
-        time = createObject("roDateTime")
-        random.append(int_to_bytes(time.asSeconds()))
-        for byte = 0 to 27
+        time = m._date_time_object
+        time.Mark()
+        m._pushInt32(random, time.asSeconds())
+        for byte = 0 to (length - 5)
             random.push(rnd(256) - 1)
         end for
         return random
     end function
-    
-    ' Send data as a TLSPlaintext record
-    ' @param self TlsUtil
-    ' @param content_type integer TLS Plaintext record type
-    ' @param payload roByteArray bytes to send
-    tls_util._send_record = function (self as object, content_type as integer, payload as object) as integer
-        if self._socket = invalid or not self._socket.isWritable()
-            printl("DEBUG", "TlsUtil: Send failed: socket is not connected")
-            return -1
-        end if
-        records = payload.count() \ self._TLS_FRAGMENT_MAX_LENGTH
-        if payload.count() mod self._TLS_FRAGMENT_MAX_LENGTH <> 0
-            records++
-        end if
-        sent_bytes = 0
-        for record_index = 0 to records - 1
-            ' Fragment
-            fragment_index = record_index * self._TLS_FRAGMENT_MAX_LENGTH
-            max = fragment_index + self._TLS_FRAGMENT_MAX_LENGTH - 1
-            if payload.count() - 1 < max
-                max = payload.count() - 1
-            end if
-            fragment = createObject("roByteArray")
-            for byte_index = fragment_index to max
-                fragment[byte_index] = payload[byte_index]
-            end for
-            ' Record
-            record = createObject("roByteArray")
-            record.push(content_type)
-            ' TLS version
-            record.append(byte_array(self._TLS_VERSION))
-            ' Length
-            record.append(short_to_bytes(fragment.count()))
-            ' Payload fragment
-            record.append(fragment)
-            printl("VERBOSE", "TlsUtil: Sending: " + record.toHexString())
-            ' Send
-            sent = self._socket.send(record, 0, record.count())
-            if sent = record.count()
-                sent_bytes += fragment.count()
-            end if
+
+    tls_util._pushBytes = sub(msg as object, number as dynamic, byteCount as integer) as void
+        for bit = (byteCount - 1) * 8 to 0 step -8
+            msg.push((number >> bit) and &hFF)
         end for
-        return sent_bytes
+    end sub
+
+    ' Push a 64-bit integer into a byte array
+    tls_util._pushLongLong = sub(msg as object, val as longinteger) as void
+        m._pushBytes(msg, val, 8)
+    end sub
+
+    ' Push a 32-bit integer into a byte array
+    tls_util._pushInt32 = sub(msg as object, val as integer) as void
+        m._pushBytes(msg, val, 4)
+    end sub
+
+    ' Push a 24-bit integer into a byte array
+    tls_util._pushInt24 = sub(msg as object, val as integer) as void
+        m._pushBytes(msg, val, 3)
+    end sub
+
+    ' Push a 16-bit integer into a byte array
+    tls_util._pushShort = sub(msg as object, val as integer) as void
+        m._pushBytes(msg, val, 2)
+    end sub
+
+    ' Push a 8-bit integer into a byte array
+    tls_util._pushChar = sub(msg as object, val as integer) as void
+        m._pushBytes(msg, val, 1)
+    end sub
+
+    tls_util._readChar = function(msg as object, offset as integer) as integer
+        return msg[offset]
     end function
-    
-    ' Send data through the TLS tunnel over the socket
-    ' @param self TlsUtil object
-    ' @param payload roByteArray data to send
-    ' @return bytes of payload sent
-    tls_util.send = function (self as object, payload as object) as integer
-        ' TODO encrypt data
-        return self._send_record(self, self._RECORD_TYPE.APPLICATION_DATA, payload)
+
+    tls_util._readShort = function(msg as object, offset as integer) as integer
+        return (m._readChar(msg, offset) << 8) or m._readChar(msg, offset + 1)
     end function
-    
-    ' Send string through the TLS tunnel over the socket
-    ' @param self TlsUtil object
-    ' @return bytes of payload sent
-    tls_util.send_str = function (self as object, payload as string) as integer
-        ba = createObject("roByteArray")
-        ba.fromAsciiString(payload)
-        return self.send(self, ba)
+
+    tls_util._readInt24 = function(msg as object, offset as integer) as integer
+        return (m._readChar(msg, offset) << 16) or m._readShort(msg, offset + 1)
     end function
-    
-    ' Set internal buffer size
-    ' @param self TlsUtil
-    ' @param size integer
-    tls_util.set_buffer_size = function (self as object, size as integer) as void
-        if self.ready_state <> self.STATE_DISCONNECTED
-            printl("WARN", "TlsUtil: Cannot set buffer size while connection is open")
-            return
+
+    tls_util._readInt32 = function(msg as object, offset as integer) as integer
+        return (m._readChar(msg, offset) << 24) or m._readInt24(msg, offset + 1)
+    end function
+
+
+    ' ----- HANDSHAKE MESSAGE CONSTRUCTION -----
+
+    tls_util._sendClientHello = function() as boolean
+        if m.clientHelloResult = invalid
+            m.clientHelloResult = false
+        else
+            return m.clientHelloResult
         end if
-        self._BUFFER_SIZE = size
+        m._logger.printl(m._logger.DEBUG, "--- Sending Client Hello ---")
+
+        ' Generate 32 bytes of random data
+        m.client_random = m.RandomByteArray(32)
+        m._logger.printl(m._logger.DEBUG, "Client Random: " + m.format_hex_bytes(m.client_random))
+
+        payload = createObject("roByteArray")
+        m._pushShort(payload, m.TLS1_2_VERSION)
+        payload.append(m.client_random)
+        m._pushChar(payload, 0) ' Session ID length
+        m._pushShort(payload, 2) ' Cipher suites length
+        m._pushShort(payload, m.CIPHER_SUITE)
+        m._pushChar(payload, 1) ' Compression methods length
+        m._pushChar(payload, 0) ' Null compression
+
+        ' Extensions
+        ext = createObject("roByteArray")
+
+        ' Server Name Indication (SNI) Extension - REQUIRED for modern servers
+        if m._hostname <> invalid and m._hostname <> ""
+            sni_data = createObject("roByteArray")
+            hostname_bytes = createObject("roByteArray")
+            hostname_bytes.fromAsciiString(m._hostname)
+
+            ' Server Name List Length (2 bytes)
+            m._pushShort(sni_data, hostname_bytes.count() + 3)
+            ' Server Name Type: host_name (0x00)
+            m._pushChar(sni_data, 0)
+            ' Server Name Length (2 bytes)
+            m._pushShort(sni_data, hostname_bytes.count())
+            ' Server Name
+            sni_data.append(hostname_bytes)
+
+            ' Add SNI extension
+            m._pushShort(ext, &h0000) ' Extension type: server_name
+            m._pushShort(ext, sni_data.count()) ' Extension length
+            ext.append(sni_data)
+            m._supported_extensions.push(&h0000)
+            m._logger.printl(m._logger.DEBUG, "Added SNI extension for hostname: " + m._hostname)
+        end if
+
+        ' Signature Algorithms Extension
+        m._pushShort(ext, &h000d) ' Extension type: signature_algorithms
+        m._pushShort(ext, &h000a) ' Extension length
+        m._pushShort(ext, &h0008) ' List length
+        m._pushShort(ext, &h0401) ' rsa_pkcs1_sha256
+        m._pushShort(ext, &h0501) ' rsa_pkcs1_sha384
+        m._pushShort(ext, &h0601) ' rsa_pkcs1_sha512
+        m._pushShort(ext, &h0201) ' rsa_pkcs1_sha1
+        m._supported_extensions.push(&h000d)
+
+        ' Add extensions length and data to payload
+        m._pushShort(payload, ext.Count())
+        payload.append(ext)
+
+        m.clientHelloResult = m._sendHandshakeMessage(m._HANDSHAKE_TYPE.CLIENT_HELLO, payload)
+        return m.clientHelloResult
     end function
-    
+
+    tls_util._sendClientKeyExchange = function() as boolean
+        if m.clientKeyExchangeResult = invalid
+            m.clientKeyExchangeResult = false
+        else
+            return m.clientKeyExchangeResult
+        end if
+        m._logger.printl(m._logger.DEBUG, "--- Sending Client Key Exchange ---")
+
+        ' Generate Pre-Master Secret
+        m.pre_master_secret = createObject("roByteArray")
+        m._pushShort(m.pre_master_secret, m.TLS1_2_VERSION)
+        pms_random = m.RandomByteArray(46)
+        m.pre_master_secret.append(pms_random)
+        m._logger.printl(m._logger.DEBUG, "Pre-Master Secret: " + m.format_hex_bytes(m.pre_master_secret))
+
+        ' Encrypt with server's public key via web service
+        encrypted_pms = m.rsa_encrypt_premaster(m.pre_master_secret)
+        if encrypted_pms = invalid
+            m._logger.printl(m._logger.FATAL, "Failed to encrypt Pre-Master Secret with server's public key.")
+            m.clientKeyExchangeResult = false
+            return m.clientKeyExchangeResult
+        end if
+
+        payload = createObject("roByteArray")
+        m._pushShort(payload, encrypted_pms.count())
+        payload.append(encrypted_pms)
+
+        m.clientKeyExchangeResult = m._sendHandshakeMessage(m._HANDSHAKE_TYPE.CLIENT_KEY_EXCHANGE, payload)
+        return m.clientKeyExchangeResult
+
+    end function
+
+    tls_util._sendChangeCipherSpecAndFinished = function() as boolean
+        if m.clientChangeCipherSent = invalid
+            m.clientChangeCipherSent = false
+        else
+            return m.clientChangeCipherSent
+        end if
+        m._logger.printl(m._logger.DEBUG, "--- Sending Change Cipher Spec & Finished ---")
+
+        ' Send Change Cipher Spec (unencrypted)
+        ccs = createObject("roByteArray")
+        m._pushChar(ccs, 1)
+        if not m._sendRecord(m._RECORD_TYPE.CHANGE_CIPHER_SPEC, ccs)
+            return false
+        end if
+
+        ' Construct Finished message
+        hexResult = m.sha256_final() ' Finalizes and resets context
+        handshake_hash = createObject("roByteArray")
+        handshake_hash.fromHexString(hexResult)
+
+        m._logger.printl(m._logger.DEBUG, "Final Handshake Hash (len:" + strI(handshake_hash.Count()) + "): " + m.format_hex_bytes(handshake_hash))
+
+        verify_data = m.prf_sha256(m.master_secret, "client finished", handshake_hash, 12)
+        m._logger.printl(m._logger.DEBUG, "Finished Verify Data    (len: " + StrI(verify_data.Count()) + "): " + m.format_hex_bytes(verify_data))
+
+        finished_payload = verify_data
+
+        ' Build the handshake message structure
+        finished_hs_msg = createObject("roByteArray")
+        m._pushChar(finished_hs_msg, m._HANDSHAKE_TYPE.FINISHED)
+        m._pushInt24(finished_hs_msg, finished_payload.count())
+        finished_hs_msg.append(finished_payload)
+
+        ' Send the Finished message (ENCRYPTED)
+        m.clientChangeCipherSent = m._sendEncryptedRecord(m._RECORD_TYPE.HANDSHAKE, finished_hs_msg)
+        return m.clientChangeCipherSent
+    end function
+
+    tls_util._sendHandshakeMessage = function(hs_type as integer, payload as object) as boolean
+        msg = createObject("roByteArray")
+        m._pushChar(msg, hs_type)
+        m._pushInt24(msg, payload.count())
+        msg.append(payload)
+
+        m.sha256_update(msg)
+        return m._sendRecord(m._RECORD_TYPE.HANDSHAKE, msg)
+    end function
+
+    tls_util._sendRecord = function(rec_type as integer, data as object) as boolean
+        header = createObject("roByteArray")
+        m._pushChar(header, rec_type)
+        m._pushShort(header, m.TLS1_2_VERSION)
+        m._pushShort(header, data.count())
+
+        bytes_sent = m._socket.send(header, 0, header.count())
+        bytes_sent += m._socket.send(data, 0, data.count())
+
+        result = bytes_sent = header.count() + data.count()
+        m._logger.printl(m._logger.DEBUG, "_sendRecord type: " + stri(rec_type) + ", len: " + stri(data.count()) + ", result: " + result.toStr())
+        m._logger.printl(m._logger.DEBUG, "_sendRecord payload: " + m.format_hex_bytes(data) + ", data string: " + data.toAsciiString())
+        return result
+    end function
+
+    tls_util._sendEncryptedRecord = function(rec_type as integer, data as object) as boolean
+        AES_BLOCK_SIZE = 16
+
+        ' 1. Calculate HMAC
+        hmac_input = createObject("roByteArray")
+        m._pushLongLong(hmac_input, m.client_seq_num)
+        m._pushChar(hmac_input, rec_type)
+        m._pushShort(hmac_input, m.TLS1_2_VERSION)
+        m._pushShort(hmac_input, data.count())
+        hmac_input.append(data)
+
+        hmac = m.hmac_sha256(m.session_keys.client_write_MAC_key, hmac_input)
+
+        ' 2. Construct plaintext: data + HMAC + padding
+        plaintext = data
+        plaintext.append(hmac)
+
+        padding_len = AES_BLOCK_SIZE - (plaintext.count() mod AES_BLOCK_SIZE)
+        padding_val = padding_len - 1
+
+        for i = 1 to padding_len
+            m._pushChar(plaintext, padding_val)
+        end for
+
+        ' 3. Generate IV and Encrypt
+        iv = m.RandomByteArray(AES_BLOCK_SIZE)
+
+        ciphertext = m.aes_256_cbc_encrypt(m.session_keys.client_write_key, iv, plaintext)
+        if ciphertext = invalid
+            return false
+        end if
+
+        ' 4. Construct final payload: IV + ciphertext and send
+        final_payload = iv
+        final_payload.append(ciphertext)
+
+        m.client_seq_num++
+        return m._sendRecord(rec_type, final_payload)
+    end function
+
+    ' Compute HMAC-SHA256 hash
+    tls_util.hmac_sha256 = function(key as object, data as object) as object
+        hmac = createObject("roHMAC")
+        if hmac = invalid
+            m._logger.printl(m._logger.FATAL, "roHMAC not available for HMAC-SHA256")
+            return invalid
+        end if
+        if hmac.setup("sha256", key) <> 0
+            m._logger.printl(m._logger.FATAL, "Failed to setup HMAC-SHA256")
+            return invalid
+        end if
+        return hmac.Process(data)
+    end function
+
+    ' Update a running SHA256 context
+    tls_util.sha256_update = sub(data as object)
+        if m.sha256_context = invalid
+            m.sha256_context = createObject("roEVPDigest")
+            if m.sha256_context.setup("sha256") <> 0
+                m._logger.printl(m._logger.FATAL, "Failed to initialize SHA256 context")
+                m.sha256_context = invalid
+                return
+            end if
+        end if
+        m._logger.printl(m._logger.DEBUG, "sha256_update with data of length: " + stri(data.count()))
+        m.sha256_context.update(data)
+    end sub
+
+    ' Finalize the running SHA256 hash and return the result
+    tls_util.sha256_final = function() as string
+        if m.sha256_context = invalid
+            m._logger.printl(m._logger.FATAL, "SHA256 context not initialized before final()")
+            return invalid
+        end if
+
+        sha256_result = m.sha256_context.final()
+
+        ' Create a new context for the next handshake
+        m.sha256_context = invalid
+
+        return sha256_result
+    end function
+
+    ' Implements the TLS 1.2 PRF (Pseudo-Random Function) using P_SHA256
+    tls_util.prf_sha256 = function(secret as object, label as string, seed as object, out_len as integer) as object
+        ' Combine label and seed
+        labelBA = createObject("roByteArray")
+        labelBA.fromAsciiString(label)
+
+        m._logger.printl(m._logger.DEBUG, "prf_sha256 secret (len:" + StrI(secret.Count()) + ") " + m.format_hex_bytes(secret))
+        m._logger.printl(m._logger.DEBUG, "prf_sha256 label (len:" + StrI(labelBA.Count()) + ") '" + label + "' - " + m.format_hex_bytes(labelBA))
+        m._logger.printl(m._logger.DEBUG, "prf_sha256 seed (len:" + StrI(seed.Count()) + ") " + m.format_hex_bytes(seed))
+
+        full_seed = labelBA
+        full_seed.append(seed)
+
+        m._logger.printl(m._logger.DEBUG, "p_hash seed (len:" + StrI(full_seed.Count()) + ") " + m.format_hex_bytes(full_seed))
+
+        ' P_hash implementation
+        result = createObject("roByteArray")
+        a = m.hmac_sha256(secret, full_seed) ' A(1)
+
+        while result.count() < out_len
+            ' HMAC(secret, A(i) + seed)
+            hmac_input = createObject("roByteArray")
+            hmac_input.append(a)
+            hmac_input.append(full_seed)
+            hmac_out = m.hmac_sha256(secret, hmac_input)
+            result.append(hmac_out)
+
+            if result.count() < out_len
+                ' A(i+1) = HMAC(secret, A(i))
+                a = m.hmac_sha256(secret, a)
+            end if
+        end while
+
+        ' Truncate to the desired length
+        return result.slice(0, out_len)
+    end function
+
+    ' Encrypt with AES-256-CBC
+    tls_util.aes_256_cbc_encrypt = function(key as object, iv as object, plaintext as object) as object
+        cipher = createObject("roEVPCipher")
+        if cipher.setup(true, "aes-256-cbc", key.toHexString(), iv.toHexString(), 0) <> 0 ' true for encryption, 0 for no padding
+            m._logger.printl(m._logger.FATAL, "Failed to setup AES-256-CBC for encryption")
+            return invalid
+        end if
+
+        result = cipher.Process(plaintext)
+        return result
+    end function
+
+    tls_util._readAndDecryptRecord = function(rec_type as integer, payload as object) as object
+        AES_BLOCK_SIZE = 16
+        SHA256_DIGEST_LENGTH = 32
+
+        ' 1. Separate IV and ciphertext
+        if payload.count() < AES_BLOCK_SIZE
+            return invalid
+        end if
+        iv = payload.slice(0, AES_BLOCK_SIZE)
+        ciphertext = payload.slice(AES_BLOCK_SIZE)
+
+        ' 2. Decrypt
+        decrypted = m.aes_256_cbc_decrypt(m.session_keys.server_write_key, iv, ciphertext)
+        if decrypted = invalid
+            return invalid
+        end if
+
+        ' 3. Strip padding
+        padding_len = decrypted[decrypted.count() - 1] + 1
+        if padding_len > decrypted.count()
+            return invalid
+        end if
+
+        data_and_mac = decrypted.slice(0, decrypted.count() - padding_len)
+
+        ' 4. Separate MAC and original data
+        if data_and_mac.count() < SHA256_DIGEST_LENGTH
+            return invalid
+        end if
+        original_data_len = data_and_mac.count() - SHA256_DIGEST_LENGTH
+        original_data = data_and_mac.slice(0, original_data_len)
+        received_hmac = data_and_mac.slice(original_data_len)
+
+        ' 5. Verify HMAC
+        hmac_input = createObject("roByteArray")
+        m._pushLongLong(hmac_input, m.server_seq_num)
+        m._pushChar(hmac_input, rec_type)
+        m._pushShort(hmac_input, m.TLS1_2_VERSION)
+        m._pushShort(hmac_input, original_data.count())
+        hmac_input.append(original_data)
+
+        calculated_hmac = m.hmac_sha256(m.session_keys.server_write_MAC_key, hmac_input)
+
+        if received_hmac.toHexString() <> calculated_hmac.toHexString()
+            m.logger.printl(m.logger.FATAL, "HMAC verification failed! Message has been tampered with.")
+            return invalid
+        end if
+
+        ' 6. Success
+        data = original_data
+        data_len = original_data_len
+        m._logger.printl(m._logger.DEBUG, "_readAndDecryptRecord decrypted data len: " + stri(data_len) + ", rec_type: " + stri(rec_type) + ", data hex: " + m.format_hex_bytes(data) + ", data string: " + data.toAsciiString())
+        m.server_seq_num++
+        return {
+            rec_type: rec_type,
+            payload: data,
+            payload_len: data_len
+        } ' Success
+    end function
+    ' Decrypt with AES-256-CBC
+    tls_util.aes_256_cbc_decrypt = function(key as object, iv as object, ciphertext as object) as object
+        cipher = createObject("roEVPCipher")
+        if cipher.setup(false, "aes-256-cbc", key.toHexString(), iv.toHexString(), 0) <> 0 ' false for decryption, 0 for no padding
+            m._logger.printl(m._logger.FATAL, "Failed to setup AES-256-CBC for decryption")
+            return invalid
+        end if
+
+        result = cipher.Process(ciphertext)
+        return result
+    end function
+
+    ' Encrypt premaster secret with RSA public key using an external Web service
+    tls_util.rsa_encrypt_premaster = function(premaster_secret as object) as object
+        m._logger.printl(m._logger.DEBUG, "TlsUtil", "Attempting RSA encryption via web service")
+        response = m.rsa_encrypt_service(premaster_secret)
+
+        if (response <> invalid) and (response.status = 200) and (type(response.body) = "roAssociativeArray") and m.isString(response.body.encrypted_data)
+            ba = createObject("roByteArray")
+            ba.fromHexString(response.body.encrypted_data)
+            if ba.count() > 0
+                m._logger.printl(m._logger.DEBUG, "TlsUtil", "RSA encryption successful via web service: " + stri(ba.count()) + " bytes returned: " + m.format_hex_bytes(ba))
+
+                return ba
+            end if
+        end if
+
+        m._logger.printl(m._logger.FATAL, "RSA encryption via web service failed: " + FormatJson(response))
+        return invalid
+    end function
+
+    ' Makes the HTTP POST call to the crypto service
+    tls_util.rsa_encrypt_service = function(premaster_secret as object) as object
+
+        response = { body: {}, headers: invalid, status: -1 }
+
+        if (m._rsa_service_info.url = invalid) or m._rsa_service_info.url.IsEmpty()
+            response.body.message = "ERROR: WebSocketClient.rsa_service_info.url is not configured!"
+            return response
+        end if
+
+        http = createObject("roUrlTransfer")
+        http.setPort(createObject("roMessagePort"))
+        http.setUrl(m._rsa_service_info.url)
+        http.setRequest("POST")
+        http.retainBodyOnError(true)
+        http.enableEncodings(true)
+        headers = {
+            "Content-Type": "application/json; charset=UTF-8"
+        }
+        if getInterface(m._rsa_service_info.headers, "ifAssociativeArray") <> invalid
+            headers.Append(m._rsa_service_info.headers)
+        end if
+        http.SetHeaders(headers)
+        hexPremaster = premaster_secret.toHexString()
+        postData = "{ ""data"": """ + hexPremaster + """ }"
+
+        #if DEBUG_LOG_WEBSOCKET
+            m._logger.printl(3, "TlsUtil", "RSA service request URL: " + m._rsa_service_info.url + Chr(10) + "HEADERS: " + FormatJson(m._rsa_service_info.headers) + Chr(10) + "BODY: " + postData)
+        #end if
+
+        didRequest = http.asyncPostFromString(postData)
+
+        if not didRequest
+            m._logger.printl(3, "TlsUtil", "RSA service request was not sent to url: " + m._rsa_service_info.url)
+            return invalid
+        end if
+
+        msg = wait(m._connect_timeout_seconds * 1000, http.getMessagePort())
+
+        if type(msg) = "roUrlEvent"
+            if msg.getInt() = 1 ' Complete
+                response.body = parseJson(msg.getString())
+                response.headers = msg.getResponseHeaders()
+                response.status = msg.getResponseCode()
+                response.url = m._rsa_service_info.url
+                #if DEBUG_LOG_WEBSOCKET
+                    m._logger.printl(m._logger.DEBUG, "TlsUtil", "RSA service request completed " + formatJson(response))
+                #end if
+            else
+                m._logger.printl(m._logger.FATAL, "RSA service request failed with code: " + stri(msg.getInt()))
+            end if
+        else if msg = invalid
+            m._logger.printl(m._logger.FATAL, "RSA service request timed out.")
+        end if
+
+        return response
+    end function
+
+    tls_util.isString = function(value as dynamic) as boolean
+        return value <> invalid and getInterface(value, "ifString") <> invalid
+    end function
+
+    tls_util.format_hex_bytes = function(data as object) as string
+        return m.two_chars_regex.replaceAll(data.toHexString(), "\1 ")
+    end function
+
     return tls_util
 end function

--- a/src/web_socket_client/WebSocketClient.brs
+++ b/src/web_socket_client/WebSocketClient.brs
@@ -5,6 +5,7 @@
 ' BrightScript web socket client (RFC 6455)
 
 ' Create a new WebSocketClient instance
+
 function WebSocketClient() as object
     ws = {}
     ' Constants
@@ -34,8 +35,9 @@ function WebSocketClient() as object
     ws._BUFFER_SLEEP = 10
     ws._BUFFER_LOOP_LIMIT = 5000 / ws._BUFFER_SLEEP ' max waiting time till try to push another value into buffer, _BUFFER_SLEEP * _BUFFER_LOOP_LIMIT
     ' Variables
-    ws._logger = Logger()
+    ws._logger = Logger("WebSocketClient")
     ws._ready_state = ws.state.CLOSED
+    ws._log_timestamp = uptime(0)
     ws._protocols = []
     ws._headers = []
     ws._secure = false
@@ -45,6 +47,7 @@ function WebSocketClient() as object
     ws._handshake = invalid
     ws._sent_handshake = false
     ws._has_received_handshake = false
+    ws._socket_open_time = 0
     ws._buffer_size = cint(1024 * 1024 * 0.5)
     ws._data = createObject("roByteArray")
     ws._data[ws._buffer_size] = 0
@@ -54,6 +57,15 @@ function WebSocketClient() as object
     ws._hostname = ""
     ws._ws_port = createObject("roMessagePort")
     ws._message_port = invalid
+    ws._connect_timeout_seconds = 0
+    ws._ping_interval_seconds = 0
+    ws._pong_max_missed = 3
+    ws._pong_timeout_seconds = 5
+    ws._pong_missed_count = 0
+    ws._rsa_service_info = {
+        url: "",
+        headers: {},
+    }
 
     ' ========== Getters ==========
 
@@ -61,14 +73,14 @@ function WebSocketClient() as object
     ' @see WebSocketClient.STATE for values
     ' @param self WebSocketClient
     ' @return integer ready state
-    ws.get_ready_state = function () as integer
+    ws.get_ready_state = function() as integer
         return m._ready_state
     end function
 
     ' Get web socket protocols sent on initial handshake
     ' @param self WebSocketClient
     ' @return roArray web socket protocols
-    ws.get_protocols = function () as object
+    ws.get_protocols = function() as object
         return m._protocols
     end function
 
@@ -76,7 +88,7 @@ function WebSocketClient() as object
     ' @param self WebSocketClient
     ' @return roArray HTTP headers - even indices are the header keys, the odd
     '         indices are the header values
-    ws.get_headers = function () as object
+    ws.get_headers = function() as object
         return m._headers
     end function
 
@@ -84,14 +96,14 @@ function WebSocketClient() as object
     ' @param self WebSocketClient
     ' @return boolean true if a TLS connection should be attempted before
     '         attempting a web socket handshake
-    ws.get_secure = function () as boolean
+    ws.get_secure = function() as boolean
         return m._secure
     end function
 
     ' Get the maximum buffer size for data sent to the websocket
     ' @param self WebSocketClient
     ' @return integer max buffer size in bytes
-    ws.get_buffer_size = function () as integer
+    ws.get_buffer_size = function() as integer
         return m._buffer_size
     end function
 
@@ -100,38 +112,38 @@ function WebSocketClient() as object
     ' Set the web socket protocols to request from the web socket server
     ' @param self WebSocketClient
     ' @param roArray of protocol strings
-    ws.set_protocols = function (protocols as object) as void
+    ws.set_protocols = sub(protocols as object) as void
         m._protocols = protocols
         m._post_message("protocols", m._protocols)
-    end function
+    end sub
 
     ' Set the headers to send on the initial HTTP request for a web socket
     ' @param self WebSocketClient
     ' @param roArray of header strings - The even indices should be the header
     '        keys and the odd are the header values
-    ws.set_headers = function (headers as object) as void
+    ws.set_headers = sub(headers as object) as void
         m._headers = headers
         m._post_message("headers", m._headers)
-    end function
+    end sub
 
     ' Set if a TLS connection should be attempted before the web socket
     ' connection
     ' @param self WebSocketClient
     ' @param secure boolean should a secure connetion be attempted
-    ws.set_secure = function (secure as boolean) as void
+    ws.set_secure = sub(secure as boolean) as void
         m._secure = secure
         m._post_message("secure", m._secure)
-    end function
+    end sub
 
     ' Set the buffer size for web socket data
     ' @param self WebSocketClient
     ' @param size integer max size of buffer in bytes
-    ws.set_buffer_size = function (size as integer) as void
+    ws.set_buffer_size = sub(size as integer) as void
         if m._ready_state <> m.STATE.CLOSED
-            m._logger.printl(m.WARN, "WebSocketClient: Cannot resize buffer on a socket that is not closed")
+            m._logger.printl(m._logger.WARN, "Cannot resize buffer on a socket that is not closed")
             return
         else if size < m._FRAME_SIZE
-            m._logger.printl(m.WARN, "WebSocketClient: Cannot set buffer to a size smaller than " + m._FRAME_SIZE.toStr() + " bytes")
+            m._logger.printl(m._logger.WARN, "Cannot set buffer to a size smaller than " + m._FRAME_SIZE.toStr() + " bytes")
             return
         end if
         m._buffer_size = size
@@ -139,43 +151,84 @@ function WebSocketClient() as object
         m._buffer[m._buffer_size] = 0
         m._data_size = 0
         m._post_message("buffer_size", m._buffer_size)
-    end function
+    end sub
 
     ' Set the message port that should be used to relay web socket events and
     ' field change updates
     ' @param self WebSocketClient
     ' @param port roMessagePort
-    ws.set_message_port = function (port as object) as void
+    ws.set_message_port = sub(port as object) as void
         m._message_port = port
-    end function
+    end sub
 
     ' Set the log level
-    ws.set_log_level = function (log_level as string) as void
+    ws.set_log_level = sub(log_level as string) as void
         m._logger.set_log_level(log_level)
-    end function
+    end sub
+
+    ws.set_connect_timeout = sub(connect_timeout as integer) as void
+        m._connect_timeout_seconds = connect_timeout
+    end sub
+
+    ws.set_close_timeout = sub(close_timeout as integer) as void
+        m._CLOSING_DELAY = close_timeout
+    end sub
+
+    ws.set_ping_interval = sub(ping_interval as integer) as void
+        m._ping_interval_seconds = ping_interval
+    end sub
+
+    ws.set_pong_max_missed = sub(pong_max_missed as integer) as void
+        m._pong_max_missed = pong_max_missed
+    end sub
+
+    ws.set_pong_timeout = sub(pong_timeout as integer) as void
+        m._pong_timeout_seconds = pong_timeout
+    end sub
+
+    ws.set_rsa_service_info = sub(service_info as object) as void
+        m._rsa_service_info = service_info
+        if m._tls <> invalid
+            m._tls.set_rsa_service_info(m._rsa_service_info)
+        end if
+    end sub
 
     ' ========== Main ==========
 
     ' Parses one websocket frame or HTTP message, if one is available
     ' @param self WebSocketClient
-    ws.run = function () as void
-        msg = wait(200, m._ws_port)
+    ws.run = sub() as void
+        msg = wait(300, m._ws_port)
         ' Socket event
         if type(msg) = "roSocketEvent"
             m._send_handshake()
             m._read_socket_data()
         end if
         m._try_force_close()
-    end function
+        m._check_pinger()
+    end sub
 
     ' Force close a connection after the close frame has been sent and no
     ' response was given, after a timeout
     ' @param self WebSocketClient
-    ws._try_force_close = function () as void
-        if m._ready_state = m.STATE.CLOSING and uptime(0) - m._started_closing >= m._CLOSING_DELAY
+    ws._try_force_close = sub() as void
+        if (m._ready_state = m.STATE.CLOSING) and ((uptime(0) - m._started_closing) >= m._CLOSING_DELAY)
             m._close()
         end if
-    end function
+        if (m._ready_state = m.STATE.OPEN) and m._secure and (m._tls.websocket_ready_state = m._tls.STATE_DISCONNECTED)
+            m._state(m.STATE.CLOSING) ' Skip trying to send close frame
+            m.close([1011, "Internal error: TLS disconnected"])
+        end if
+
+        ' Check if open connection is
+        ' If we've been stuck for too long, reset and retry
+        if (m._ready_state = m.STATE.CONNECTING) and ((uptime(0) - m._socket_open_time) >= m._connect_timeout_seconds)
+            #if DEBUG_LOG_WEBSOCKET
+                m._logger.printl(m._logger.DEBUG, "WebSocket connect timed out, resetting connection")
+            #end if
+            m._close(1006, "WebSocket connect timed out")
+        end if
+    end sub
 
     ' Sends data through the socket
     ' @param self WebSocketClient
@@ -184,23 +237,23 @@ function WebSocketClient() as object
     '                        is for a control frame
     ' @param _opcode int - define a **control** opcode data opcodes are determined
     '                      by the type of the passed message
-    ' @param silent boolean - does not send on_error event
+    ' @param silent boolean - does not send on_websocket_error event
     ' @param do_close boolean - if true, a close frame will be sent on errors
     ' @return integer amount of bytes sent
-    ws.send = function (message as dynamic, _opcode = -1 as integer, silent = false as boolean, do_close = true as boolean) as integer
-        if m._socket = invalid or not m._socket.isWritable()
-            m._logger.printl(m._logger.DEBUG, "WebSocketClient: Failed to send data: socket is closed")
+    ws.send = function(message as dynamic, _opcode = -1 as integer, silent = false as boolean, do_close = true as boolean) as integer
+        if m._socket = invalid or not m.rawSocketConected
+            m._logger.printl(m._logger.DEBUG, "Failed to send data: socket is closed")
             return -1
         end if
         if m._ready_state <> m.STATE.OPEN
-            m._logger.printl(m._logger.DEBUG, "WebSocketClient: Failed to send data: connection not open")
+            m._logger.printl(m._logger.DEBUG, "Failed to send data: connection not open")
             return -1
         end if
         if type(message) = "roString" or type(message) = "String" or type(message) = "roByteArray"
             message = [message]
         end if
         if message.count() <> 1
-            m._logger.printl(m._logger.DEBUG, "WebSocketClient: Failed to send data: too many parameters")
+            m._logger.printl(m._logger.DEBUG, "Failed to send data: too many parameters")
             return -1
         end if
         bytes = createObject("roByteArray")
@@ -214,30 +267,30 @@ function WebSocketClient() as object
             end for
             opcode = m.OPCODE.BINARY
         else
-            m._logger.printl(m._logger.DEBUG, "WebSocketClient: Failed to send data: invalid parameter type")
+            m._logger.printl(m._logger.DEBUG, "Failed to send data: invalid parameter type")
             return -1
         end if
         if _opcode > -1 and (_opcode >> 3) <> 1
-            m._logger.printl(m._logger.DEBUG, "WebSocketClient: Failed to send data: specified opcode was not a control opcode")
+            m._logger.printl(m._logger.DEBUG, "Failed to send data: specified opcode was not a control opcode")
             return -1
         else if _opcode > -1
             if bytes.count() > 125
-                m._logger.printl(m._logger.DEBUG, "WebSocketClient: Failed to send data: control frames cannot have a payload larger than 125 bytes")
+                m._logger.printl(m._logger.DEBUG, "Failed to send data: control frames cannot have a payload larger than 125 bytes")
                 return -1
             end if
             opcode = _opcode
         end if
         ' Frame message
         frame_count = bytes.count() \ m._FRAME_SIZE
-        if bytes.count() mod m._FRAME_SIZE <> 0 or frame_count = 0
+        if ((bytes.count() mod m._FRAME_SIZE) <> 0) or (frame_count = 0)
             frame_count++
         end if
         total_sent = 0
-        for frame_index = 0 to frame_count - 1
+        for frame_index = 0 to (frame_count - 1)
             ' Get sub array of payload bytes
             payload = createObject("roByteArray")
             max = bytes.count() - 1
-            if  (frame_index + 1) * m._FRAME_SIZE - 1 < max
+            if (frame_index + 1) * m._FRAME_SIZE - 1 < max
                 max = (frame_index + 1) * m._FRAME_SIZE - 1
             end if
             for byte_index = frame_index * m._FRAME_SIZE to max
@@ -286,19 +339,19 @@ function WebSocketClient() as object
             frame.append(masked_payload)
             ' Send frame
             if _opcode <> m.OPCODE.PING
-                m._logger.printl(m._logger.VERBOSE, "WebSocketClient: Sending frame: " + frame.toHexString())
+                m._logger.printl(m._logger.VERBOSE, "Sending frame (" + (frame_index + 1).ToStr() + " of " + frame_count.ToStr() + "): " + frame.toHexString() + ", data string: " + payload.toAsciiString())
             end if
             sent = 0
             if m._secure
-                sent = m._tls.send(m._tls, frame)
+                sent = m._tls.send(frame)
             else
                 sent = m._socket.send(frame, 0, frame.count())
             end if
             if _opcode <> m.OPCODE.PING
-                m._logger.printl(m._logger.VERBOSE, "WebSocketClient: Sent " + sent.toStr() + " bytes")
+                m._logger.printl(m._logger.VERBOSE, "Sent " + sent.toStr() + " bytes")
                 loop_wait = 0
                 while m._socket.GetCountSendBuf() > m._BUFFER_SOCKET_SIZE
-                    m._logger.printl(m._logger.VERBOSE, "WebSocketClient: Sleeping " + m._BUFFER_SLEEP.toStr() + "ms to reduce buffer")
+                    m._logger.printl(m._logger.VERBOSE, "Sleeping " + m._BUFFER_SLEEP.toStr() + "ms to reduce buffer")
                     sleep(m._BUFFER_SLEEP)
                     if loop_wait > m._BUFFER_LOOP_LIMIT
                         exit while
@@ -322,21 +375,41 @@ function WebSocketClient() as object
 
     ' Send the initial websocket handshake if it has not been sent
     ' @param self WebSocketClient
-    ws._send_handshake = function () as void
-        if m._socket = invalid or not m._socket.isWritable() or m._sent_handshake or m._handshake = invalid or m._tls.ready_state = m._tls.STATE_CONNECTING
+    ws._send_handshake = sub() as void
+        if m._ready_state = m.STATE.OPEN
             return
         end if
-        if m._secure and m._tls.ready_state = m._tls.STATE_DISCONNECTED
-            m._tls.connect(m._tls, m._hostname)
+        #if DEBUG_LOG_WEBSOCKET
+            now = uptime(0)
+            doRepetitiveLog = (m._log_timestamp + 1.0) < now
+            if doRepetitiveLog
+                m._log_timestamp = now
+                m._logger.printl(m._logger.DEBUG, "_send_handshake socket: " + (m._socket <> invalid).toStr() + ", rawSocketConected=" + m.rawSocketConected.toStr() + ", secure=" + m._secure.toStr() + ", sent_handshake=" + m._sent_handshake.toStr() + ", handshake=" + (m._handshake <> invalid).toStr() + ", tls_state=" + m._tls?.websocket_ready_state.toStr())
+            end if
+        #end if
+
+        if m._socket = invalid or not m.rawSocketConected or m._sent_handshake or m._handshake = invalid or (m._secure and m._tls.websocket_ready_state = m._tls.STATE_CONNECTING)
+            #if DEBUG_LOG_WEBSOCKET
+                if doRepetitiveLog
+                    m._logger.printl(m._logger.DEBUG, "Not ready for handshake socket: " + (m._socket <> invalid).toStr() + ", rawSocketConected=" + m.rawSocketConected.toStr() + ", sent_handshake=" + m._sent_handshake.toStr() + ", handshake=" + (m._handshake <> invalid).toStr() + ", tls_state=" + m._tls?.websocket_ready_state.toStr())
+                end if
+            #end if
+            return
+        end if
+        if m._secure and m._tls.websocket_ready_state = m._tls.STATE_DISCONNECTED
+            #if DEBUG_LOG_WEBSOCKET
+                m._logger.printl(m._logger.DEBUG, "Establshing TLS ...")
+            #end if
+            m._tls.connect(m._hostname)
         else
             m._logger.printl(m._logger.VERBOSE, m._handshake)
             sent = 0
             if m._secure
-                sent = m._tls.send_str(m._tls, m._handshake)
+                sent = m._tls.send_str(m._handshake)
             else
                 sent = m._socket.sendStr(m._handshake)
             end if
-            m._logger.printl(m._logger.VERBOSE, "WebSocketClient: Sent " + sent.toStr() + " bytes")
+            m._logger.printl(m._logger.VERBOSE, "Sent " + sent.toStr() + " bytes")
             if sent = -1
                 m._close()
                 m._error(4, "Failed to send data: " + m._socket.status().toStr())
@@ -344,12 +417,12 @@ function WebSocketClient() as object
             end if
             m._sent_handshake = true
         end if
-    end function
+    end sub
 
     ' Read socket data
     ' @param self WebSocketClient
-    ws._read_socket_data = function () as void
-        if m._socket = invalid or m._ready_state = m.STATE.CLOSED or (m._secure and m._tls.ready_state = m._tls.STATE_DISCONNECTED)
+    ws._read_socket_data = sub() as void
+        if m._socket = invalid or m._ready_state = m.STATE.CLOSED or (m._secure and m._tls.websocket_ready_state = m._tls.STATE_DISCONNECTED)
             return
         end if
         buffer = createObject("roByteArray")
@@ -364,7 +437,7 @@ function WebSocketClient() as object
             return
         end if
         if m._secure
-            buffer = m._tls.read(m._tls, buffer, bytes_received)
+            buffer = m._tls.read(buffer, bytes_received)
             if buffer = invalid
                 m._close()
                 m._error(17, "TLS error")
@@ -464,19 +537,19 @@ function WebSocketClient() as object
                     end if
                 end for
                 ' Handle the message
-                m._logger.printl(m._logger.VERBOSE, "WebSocketClient: Message: " + message)
+                m._logger.printl(m._logger.VERBOSE, "Message: " + message)
                 m._handle_handshake_response(message)
             end if
             m._data.fromAsciiString(data)
         end if
         m._data_size = m._data.count()
         m._data[m._buffer_size] = 0
-    end function
+    end sub
 
     ' Handle the handshake message or die trying
     ' @param self WebSocketClient
     ' @param string http response header
-    ws._handle_handshake_response = function (message as string) as void
+    ws._handle_handshake_response = sub(message as string) as void
         lines = message.split(m._NL)
         if lines.count() = 0
             m._close()
@@ -552,35 +625,41 @@ function WebSocketClient() as object
         end for
         m._has_received_handshake = true
         m._state(m.STATE.OPEN)
-        m._post_message("on_open", {
+        m._post_message("on_websocket_open", {
             protocol: protocol
         })
-    end function
+        m._start_pinger()
+    end sub
 
     ' Post a message to the message port
     ' @param self WebSocketClient
     ' @param id string message event id
     ' @param data dynamic message data
-    ws._post_message = function (id as string, data as dynamic) as void
+    ws._post_message = sub(id as string, data as dynamic) as void
         if m._message_port <> invalid
             m._message_port.postMessage({
                 id: id,
                 data: data
             })
         end if
-    end function
+    end sub
 
     ' Handle a web socket frame
     ' @param self WebSocketClient
     ' @param opcode int opcode
     ' @param payload roByteArray payload data
-    ws._handle_frame = function (opcode as integer, payload as object) as void
+    ws._handle_frame = sub(opcode as integer, payload as object) as void
         if opcode <> m.OPCODE.PONG
-            frame_print  = "WebSocketClient: " + "Received frame:" + m._NL
+            frame_print = "" + "Received frame:" + m._NL
             frame_print += "  Opcode: " + opcode.toStr() + m._NL
             frame_print += "  Payload: " + payload.toHexString()
             m._logger.printl(m._logger.VERBOSE, frame_print)
         end if
+
+        if m._is_ping_enabled() and (not m._is_ping_sent)
+            m._mark_ping_pong_time() ' delay next ping since the channel is active
+        end if
+
         ' Close
         if opcode = m.OPCODE.CLOSE
             m._close()
@@ -589,9 +668,15 @@ function WebSocketClient() as object
         else if opcode = m.OPCODE.PING
             m.send("", m.OPCODE.PONG)
             return
+            ' Pong
+        else if opcode = m.OPCODE.PONG
+            if m._is_ping_enabled()
+                m._on_pong_received(payload)
+            end if
+            return
             ' Text
         else if opcode = m.OPCODE.TEXT
-            m._post_message("on_message", {
+            m._post_message("on_websocket_message", {
                 type: 0,
                 message: payload.toAsciiString()
             })
@@ -602,21 +687,20 @@ function WebSocketClient() as object
             for each byte in payload
                 payload_array.push(byte)
             end for
-            m._post_message("on_message", {
+            m._post_message("on_websocket_message", {
                 type: 1,
                 message: payload_array
             })
             return
         end if
-    end function
+    end sub
 
-    ' Generate a 16 character [A-Za-z0-9] random string and base64 encode it
-    ' @link https://tools.ietf.org/html/rfc6455#section-4.1
+    ' Generate a 20 character [A-Za-z0-9] random string and base64 encode it
     ' @param self WebSocketClient
-    ' @return string random 16 character base64 encoded string
-    ws._generate_sec_ws_key = function () as string
+    ' @return string random 20 character base64 encoded string
+    ws._generate_sec_ws_key = function() as string
         sec_ws_key = ""
-        for char_index = 0 to 15
+        for char_index = 0 to 19
             char = m._CHARS[rnd(m._CHARS.count()) - 1]
             if rnd(2) = 1
                 char = ucase(char)
@@ -634,37 +718,50 @@ function WebSocketClient() as object
     '                   Format: ws://example.org:80/
     '                   If the port is not specified the port will be assumed
     '                   from the protocol (ws: 80, wss: 443).
-    ws.open = function (url as string) as void
+    ws.open = sub(url as string) as void
         if m._ready_state <> m.STATE.CLOSED
-            m._logger.printl(m._logger.DEBUG, "WebSocketClient: Tried to open a web socket that was already open")
+            m._logger.printl(m._logger.DEBUG, "Tried to open a web socket that was already open")
             return
         end if
+        #if DEBUG_LOG_WEBSOCKET
+            m._logger.printl(m._logger.DEBUG, "Opening URL: " + url)
+        #end if
         if m._REGEX_URL.isMatch(url)
             match = m._REGEX_URL.match(url)
             ws_type = lcase(match[1])
             host = lcase(match[2])
             port = match[3]
             path = match[4]
+            #if DEBUG_LOG_WEBSOCKET
+                m._logger.printl(m._logger.DEBUG, "Parsed URL: " + FormatJson({
+                    ws_type: ws_type,
+                    host: host,
+                    port: port,
+                    path: path,
+                }))
+            #end if
             m._hostname = host
             ' Port
-            if port <> ""
-                port = val(port, 10)
-            else if ws_type = "wss"
+            if ws_type = "wss"
                 m.set_secure(true)
-                port = 443
             else if ws_type = "ws"
-                port = 80
+                m.set_secure(false)
             else
                 m._close()
                 m._error(0, "Invalid web socket type specified: " + ws_type)
                 return
             end if
+            if port <> ""
+                port = val(port, 10)
+            else if m._secure
+                port = 443
+            else
+                port = 80
+            end if
             ' Path
             if path = ""
                 path = "/"
             end if
-            ' WS(S) to HTTP(S)
-            scheme = ws_type.replace("ws", "http")
             ' Construct handshake
             m._sec_ws_key = m._generate_sec_ws_key()
             protocols = ""
@@ -674,7 +771,7 @@ function WebSocketClient() as object
             if protocols <> ""
                 protocols = protocols.left(len(protocols) - 2)
             end if
-            handshake =  "GET " + path + " HTTP/1.1" +m._NL
+            handshake = "GET " + path + " HTTP/1.1" + m._NL
             handshake += "Host: " + host + ":" + port.toStr() + m._NL
             handshake += "Upgrade: websocket" + m._NL
             handshake += "Connection: Upgrade" + m._NL
@@ -688,11 +785,14 @@ function WebSocketClient() as object
             handshake += m._NL
             m._handshake = handshake
             ' Create socket
+            m.rawSocketConected = false
             m._state(m.STATE.CONNECTING)
             address = createObject("roSocketAddress")
             address.setHostName(host)
             address.setPort(port)
+
             if not address.isAddressValid()
+                m._logger.printl(m._logger.FATAL, "Invalid hostname: " + host + ":" + port.ToStr())
                 m._close()
                 m._error(2, "Invalid hostname")
                 return
@@ -710,22 +810,38 @@ function WebSocketClient() as object
             m._socket.setSendToAddress(address)
             m._sent_handshake = false
             m._has_received_handshake = false
-            m._tls = TlsUtil(m._socket)
-            m._tls.set_buffer_size(m._tls, m._buffer_size)
+            m._tls = TlsUtil()
+            m._tls.set_log_level_int(m._logger.log_level)
+            m._tls.set_socket(m._socket)
+            m._tls.set_buffer_size(m._buffer_size)
+            m._tls.set_rsa_service_info(m._rsa_service_info)
+            m._tls.set_connect_timeout_seconds(m._connect_timeout_seconds)
             if not m._socket.connect()
                 m._close()
-                m._error(3, "Socket failed to connect: " + m._socket.status().toStr())
+                errMsg = "Socket failed to connect: " + m._socket.status().toStr()
+                m._logger.printl(m._logger.FATAL, "" + errMsg)
+                m._error(3, errMsg)
                 return
             end if
+            m.rawSocketConected = true
+            m._socket_open_time = uptime(0) ' Record when Web-Socket as open
+            #if DEBUG_LOG_WEBSOCKET
+                m._logger.printl(m._logger.DEBUG, "WebSocketClient open success: " + FormatJson({
+                    ws_type: ws_type,
+                    host: host,
+                    port: port,
+                    path: path,
+                }))
+            #end if
         else
             m._close()
             m._error(1, "Invalid URL specified")
         end if
-    end function
+    end sub
 
     ' Parse header array and return a string of headers delimited by CRLF
     ' @param self WebSocketClient
-    ws._get_parsed_user_headers = function () as string
+    ws._get_parsed_user_headers = function() as string
         if m._headers = invalid or m._headers.count() = 0 or (m._headers.count() mod 2) = 1
             return ""
         end if
@@ -741,29 +857,29 @@ function WebSocketClient() as object
     ' Set ready state
     ' @param self WebSocketClient
     ' @param state
-    ws._state = function (_state as integer) as void
+    ws._state = sub(_state as integer) as void
         m._ready_state = _state
-        m._post_message("ready_state", _state)
-    end function
+        m._post_message("websocket_ready_state", _state)
+    end sub
 
     ' Send an error event
-    ' Posts an on_error message to the message port
+    ' Posts an on_websocket_error message to the message port
     ' @param self WebSocketClient
     ' @param code integer error code
     ' @param message string error message
-    ws._error = function (code as integer, message as string) as void
-        m._logger.printl(m._logger.EXTRA, "WebSocketClient: Error: " + message)
-        m._post_message("on_error", {
+    ws._error = sub(code as integer, message as string) as void
+        m._logger.printl(m._logger.EXTRA, "Error: " + message)
+        m._post_message("on_websocket_error", {
             code: code,
             message: message
         })
-    end function
+    end sub
 
     ' Close the socket
     ' @param WebSocketClient
     ' @param code integer -  status code
     ' @param reason roByteArray - reason
-    ws._close = function (code = 1000 as integer, reason = invalid as object) as void
+    ws._close = sub(code = 1000 as integer, reason = invalid as object) as void
         if m._socket <> invalid
             ' Send the closing frame
             if m._ready_state = m.STATE.OPEN
@@ -772,19 +888,22 @@ function WebSocketClient() as object
                 m._state(m.STATE.CLOSING)
             else
                 m._state(m.STATE.CLOSED)
-                m._post_message("on_close", "")
+                m._post_message("on_websocket_close", {
+                    code: code,
+                    reason: reason
+                })
                 m._socket.close()
             end if
         else if m._ready_state <> m.STATE.CLOSED
             m._state(m.STATE.CLOSED)
         end if
-    end function
+    end sub
 
     ' Send a close frame to the server to initiate a close
     ' @param self WebSocketClient
     ' @param code integer -  status code
     ' @param reason roByteArray - reason
-    ws._send_close_frame = function (code as integer, reason as dynamic) as void
+    ws._send_close_frame = sub(code as integer, reason as dynamic) as void
         message = createObject("roByteArray")
         message.push(code >> 8)
         message.push(code)
@@ -792,30 +911,87 @@ function WebSocketClient() as object
             message.append(reason)
         end if
         m.send(message, m.OPCODE.CLOSE, true, false)
-    end function
+    end sub
 
     ' Close the socket
     ' @self WebSocketClient
     ' @param reason array - array [code as integer, message as roString]
-    ws.close = function (params as object) as void
+    ws.close = sub(params as object) as void
+        #if DEBUG_LOG_WEBSOCKET
+            m._logger.printl(m._logger.DEBUG, "close params: " + FormatJson(params))
+        #end if
         code = 1000
         reason = createObject("roByteArray")
         if params.count() > 0
             code = params[0]
-            if type(code) <> "Integer" or code > &hffff
-                m._logger.printl(m._logger.DEBUG, "WebSocketClient: close expects value at array index 0 to be a 16-bit integer")
+            if (getInterface(code, "ifInt") = invalid) or code > &hffff
+                m._logger.printl(m._logger.DEBUG, "close expects value at array index 0 to be a 16-bit integer")
             end if
         end if
         if params.count() > 1
             message = params[1]
-            if type(message) <> "roString" or type(message) <> "String"
+            if getInterface(message, "ifString") <> invalid
                 reason.fromAsciiString(message)
             else
-                m._logger.printl(m._logger.DEBUG, "WebSocketClient: close expects value at array index 1 to be a string")
+                m._logger.printl(m._logger.DEBUG, "close expects value at array index 1 to be a string")
             end if
         end if
         m._close(code, reason)
+    end sub
+
+    ws._is_ping_enabled = function() as boolean
+        return m._ping_interval_seconds > 0
     end function
+
+    ws._start_pinger = sub() as void
+        if not (m._is_ping_enabled() and (m._ready_state = m.STATE.OPEN))
+            return
+        end if
+
+        m._logger.printl(m._logger.DEBUG, "starting pinger with interval: " + m._ping_interval_seconds.ToStr() + " seconds")
+        m._is_ping_sent = false
+        m._pong_missed_count = 0
+        m._ping_pong_timestamp = 0
+        m._mark_ping_pong_time()
+    end sub
+
+    ws._check_pinger = sub() as void
+        if not (m._is_ping_enabled() and (m._ready_state = m.STATE.OPEN))
+            return
+        end if
+
+        seconds_since = uptime(0) - m._ping_pong_timestamp
+        if m._is_ping_sent and (seconds_since >= m._pong_timeout_seconds)
+            m._pong_missed_count += 1
+            m._is_ping_sent = false
+            seconds_since = m._ping_interval_seconds ' Force send ping
+            m._logger.printl(m._logger.DEBUG, "pinger missed " + m._pong_missed_count.ToStr() + " from " + m._pong_max_missed.ToStr())
+        end if
+
+        if m._pong_missed_count >= m._pong_max_missed
+            message = "pinger: ping timeout after " + m._pong_missed_count.ToStr() + " PONG message"
+            m._logger.printl(m._logger.WARN, "" + message)
+            m.close([1011, message])
+        else if (not m._is_ping_sent) and (seconds_since >= m._ping_interval_seconds)
+            m._is_ping_sent = true
+            m._mark_ping_pong_time()
+            m._logger.printl(m._logger.DEBUG, "pinger sending PING " + (m._pong_missed_count + 1).ToStr() + " of " + m._pong_max_missed.ToStr())
+            m.send("", m.OPCODE.PING)
+        end if
+
+    end sub
+
+    ws._on_pong_received = sub(payload as object) as void
+        if m._is_ping_sent
+            m._is_ping_sent = false
+            m._mark_ping_pong_time()
+            m._logger.printl(m._logger.DEBUG, "pinger PONG received")
+        end if
+    end sub
+
+    ws._mark_ping_pong_time = sub() as void
+        m._ping_pong_timestamp = uptime(0)
+    end sub
 
     ' Return constructed instance
     return ws

--- a/src/web_socket_client/WebSocketClientTask.brs
+++ b/src/web_socket_client/WebSocketClientTask.brs
@@ -5,27 +5,9 @@
 ' BrightScript, SceneGraph Task wrapper for the web socket client
 
 ' Entry point
-function init() as void
+sub init() as void
     ' Task init
-    m.top.functionName = "run"
-    m.top.control = "RUN"
-end function
-
-' Main task loop
-function run() as void
-    m.ws = WebSocketClient()
     m.port = createObject("roMessagePort")
-    m.ws.set_message_port(m.port)
-    ' Fields
-    m.top.STATE_CONNECTING = m.ws.STATE.CONNECTING
-    m.top.STATE_OPEN = m.ws.STATE.OPEN
-    m.top.STATE_CLOSING = m.ws.STATE.CLOSING
-    m.top.STATE_CLOSED = m.ws.STATE.CLOSED
-    m.top.ready_state = m.ws.get_ready_state()
-    m.top.protocols = m.ws.get_protocols()
-    m.top.headers = m.ws.get_headers()
-    m.top.secure = m.ws.get_secure()
-    m.top.buffer_size = m.ws.get_buffer_size()
     ' Event listeners
     m.top.observeField("open", m.port)
     m.top.observeField("send", m.port)
@@ -35,16 +17,44 @@ function run() as void
     m.top.observeField("headers", m.port)
     m.top.observeField("secure", m.port)
     m.top.observeField("log_level", m.port)
+    m.top.observeField("ping_interval", m.port)
+    m.top.observeField("rsa_service_info", m.port)
 
-    if len(m.top.open) > 0
-        m.ws.open(m.top.open)
-    end if
+    m.ws = WebSocketClient()
+    m.ws.set_message_port(m.port)
 
+    m.ws.set_connect_timeout(m.top.connect_timeout)
+    m.ws.set_close_timeout(m.top.close_timeout)
+    m.ws.set_ping_interval(m.top.ping_interval)
+    m.ws.set_pong_max_missed(m.top.pong_max_missed)
+    m.ws.set_pong_timeout(m.top.pong_timeout)
+    m.ws.set_rsa_service_info(m.top.rsa_service_info)
+
+    ' Fields
+    m.top.STATE_CONNECTING = m.ws.STATE.CONNECTING
+    m.top.STATE_OPEN = m.ws.STATE.OPEN
+    m.top.STATE_CLOSING = m.ws.STATE.CLOSING
+    m.top.STATE_CLOSED = m.ws.STATE.CLOSED
+    m.top.websocket_ready_state = m.ws.get_ready_state()
+    m.top.protocols = m.ws.get_protocols()
+    m.top.headers = m.ws.get_headers()
+    m.top.secure = m.ws.get_secure()
+    m.top.buffer_size = m.ws.get_buffer_size()
+
+    m.top.functionName = "WebSocketLoop"
+    m.top.control = "RUN"
+end sub
+
+' Main task loop
+sub WebSocketLoop() as void
     while true
         ' Check task messages
-        msg = wait(1, m.port)
+        msg = wait(25, m.port)
         ' Field event
         if type(msg) = "roSGNodeEvent"
+            #if DEBUG_LOG_WEBSOCKET
+                m.ws._logger.printl(m.ws._logger.DEBUG, "WebSocketLoop: roSGNodeEvent for " + msg.getNode().ToStr() + ", field: " + msg.getField() + ", data: " + FormatJson(msg.getData()))
+            #end if
             if msg.getField() = "open"
                 m.ws.open(msg.getData())
             else if msg.getField() = "send"
@@ -61,19 +71,34 @@ function run() as void
                 m.ws.set_secure(msg.getData())
             else if msg.getField() = "log_level"
                 m.ws.set_log_level(msg.getData())
+            else if msg.getField() = "connect_timeout"
+                m.ws.set_connect_timeout(msg.getData())
+            else if msg.getField() = "close_timeout"
+                m.ws.set_close_timeout(msg.getData())
+            else if msg.getField() = "ping_interval"
+                m.ws.set_ping_interval(msg.getData())
+            else if msg.getField() = "pong_max_missed>"
+                m.ws.set_pong_max_missed(msg.getData())
+            else if msg.getField() = "pong_timeout"
+                m.ws.set_pong_timeout(msg.getData())
+            else if msg.getField() = "rsa_service_info"
+                m.ws.set_rsa_service_info(msg.getData())
             end if
             ' WebSocket event
         else if type(msg) = "roAssociativeArray"
-            if msg.id = "on_open"
-                m.top.on_open = msg.data
-            else if msg.id = "on_close"
-                m.top.on_close = msg.data
-            else if msg.id = "on_message"
-                m.top.on_message = msg.data
-            else if msg.id = "on_error"
-                m.top.on_error = msg.data
-            else if msg.id = "ready_state"
-                m.top.ready_state = msg.data
+            #if DEBUG_LOG_WEBSOCKET
+                m.ws._logger.printl(m.ws._logger.DEBUG, "WebSocketLoop: roSGNodeEvent for " + msg.id + ", data: " + FormatJson(msg.data))
+            #end if
+            if msg.id = "on_websocket_open"
+                m.top.on_websocket_open = msg.data
+            else if msg.id = "on_websocket_close"
+                m.top.on_websocket_close = msg.data
+            else if msg.id = "on_websocket_message"
+                m.top.on_websocket_message = msg.data
+            else if msg.id = "on_websocket_error"
+                m.top.on_websocket_error = msg.data
+            else if msg.id = "websocket_ready_state"
+                m.top.websocket_ready_state = msg.data
             else if msg.id = "buffer_size"
                 m.top.unobserveField("buffer_size")
                 m.top.buffer_size = msg.data
@@ -92,6 +117,8 @@ function run() as void
                 m.top.observeField("secure", m.task_port)
             end if
         end if
-        m.ws.run()
+        if msg = invalid
+            m.ws.run()
+        end if
     end while
-end function
+end sub

--- a/test/components/Main.xml
+++ b/test/components/Main.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component name="Main" extends="Scene">
 
+	<interface>
+		<field id="message" type="string" alias="messageLabel.text" />
+	</interface>
+
 	<children>
 	
 		<Label
@@ -9,11 +13,22 @@
 			color="0xffffff"
 			font="font:LargeBoldSystemFont"
 			width="1280"
-			height="720"
+			height="140"
 			translation="[0,0]"
 			horizAlign="center"
 			vertAlign="center" />
 			
+		<Label
+			id="messageLabel"
+			inheritParentOpacity="false"
+			width="1200"
+			height="540"
+			horizAlign="left"
+			translation="[40,160]"
+			leadingEllipsis="true"
+			wrap="true">
+			<Font role="font" uri="font:SystemFontFile" size="18" />
+        </Label>
 	</children>
 	
 	<script type="text/brightscript" uri="pkg:/source/Main.brs" />

--- a/test/manifest
+++ b/test/manifest
@@ -13,3 +13,4 @@ splash_color=#121212
 splash_min_time=0
 ui_resolutions=hd
 mm_icon_focus_fhd=pkg:/images/icon_focus_hd.png
+bs_const=DEBUG=false;DEBUG_LOG_WEBSOCKET=false

--- a/test/source/Main.brs
+++ b/test/source/Main.brs
@@ -21,16 +21,36 @@ end function
 ' Entry point for the main scene
 function init() as void
     m.ws = createObject("roSGNode", "WebSocketClient")
-    m.ws.observeField("on_open", "on_open")
-    m.ws.observeField("on_close", "on_close")
-    m.ws.observeField("on_message", "on_message")
-    m.ws.observeField("on_error", "on_error")
+    m.ws.observeField("on_websocket_open", "on_open")
+    m.ws.observeField("on_websocket_close", "on_close")
+    m.ws.observeField("on_websocket_message", "on_message")
+    m.ws.observeField("on_websocket_error", "on_error")
     m.ws.protocols = []
     m.ws.headers = []
-    m.ws.log_level = "INFO"
-    m.SERVER = "ws://echo.websocket.org/"
+    #if DEBUG_LOG_WEBSOCKET
+        m.ws.log_level = "VERBOSE"
+    #else
+        m.ws.log_level = "INFO"
+    #end if
+
+    ' Plain-text WebSocket server, e.g. util/echo/websocket_echo_server.js
+    ' m.SERVER = "ws://10.42.0.1:5000/"
+
+    ' Secure WebSocket server, e.g. util/echo/websocket_echo_server_ssl.js server.key server.cer 5001
+    ' rsa_service must also be started
+    '```
+    ' python util/crypto_server/rsa_server.py --port 5002 --certificate server.cer
+    '````
+    ' Configure server for RSA encryption of the pre-master secret
+    m.SERVER = "wss://10.42.0.1:5001/"
+    m.ws.rsa_service_info = {
+        url: "http://10.42.0.1:5002/encrypt",
+        headers: {},
+    }
     m.ws.open = m.SERVER
     m.reinitialize = false
+    m._date_time_object = createObject("roDateTime")
+    m._new_line_regex = CreateObject("roRegex", "\n", "")
 end function
 
 ' Key events
@@ -38,6 +58,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if key = "back" and press
         print "Closing websocket"
         m.ws.close = [1000, "optional"]
+        return true
     else if key = "OK" and press
         print "Reinitializing websocket"
         if m.ws.ready_state <> m.ws.STATE_CLOSED
@@ -46,31 +67,35 @@ function onKeyEvent(key as string, press as boolean) as boolean
         else
             m.ws.open = m.SERVER
         end if
+        return true
     end if
+    return false
 end function
 
 ' Socket open event
 function on_open(event as object) as void
-    print "WebSocket opened"
-    print tab(2)"Protocol: " + event.getData().protocol
+    show_message("WebSocket opened")
+    show_message("Protocol: " + FormatJson(event.getData()))
     send_test_data()
 end function
 
 ' Send test data to the websocket
 function send_test_data() as void
-    print "Sending string: test string"
-    m.ws.send = ["test string"]
+    test_string = "test string"
+    show_message("Sending string: " + test_string)
+    m.ws.send = [test_string]
     test_binary = []
     for bin = 0 to 3
         test_binary.push(bin)
     end for
-    print "Sending data: 00010203"
+    show_message("Sending binary data: 00010203")
     m.ws.send = [test_binary]
 end function
 
 ' Socket close event
 function on_close(event as object) as void
-    print "WebSocket closed"
+    show_message("WebSocket closed")
+
     if m.reinitialize
         m.ws.open = m.SERVER
         m.reinitialize = false
@@ -81,18 +106,50 @@ end function
 function on_message(event as object) as void
     message = event.getData().message
     if type(message) = "roString"
-        print "WebSocket text message: " + message
+        show_message("<-- WebSocket text message: " + message)
     else
         ba = createObject("roByteArray")
         for each byte in message
             ba.push(byte)
         end for
-        print "WebSocket binary message: " + ba.toHexString()
+        show_message("<-- WebSocket binary message: " + ba.toHexString())
     end if
 end function
 
 ' Socket Error event
 function on_error(event as object) as void
-    print "WebSocket error"
-    print event.getData()
+    show_message("WebSocket error: " + FormatJson(event.GetData()))
 end function
+
+function curent_timestamp() as string
+    dateTime = m._date_time_object
+    dateTime.Mark()
+    dateTime.ToLocalTime()
+
+    hours = dateTime.GetHours().ToStr("%02d")
+    minutes = dateTime.GetMinutes().ToStr("%02d")
+    seconds = dateTime.GetSeconds().ToStr("%02d")
+    milliseconds = dateTime.GetMilliseconds().ToStr("%03d")
+
+    return "[" + hours + ":" + minutes + ":" + seconds + "." + milliseconds + "]"
+end function
+
+sub show_message(message as string)
+    message = curent_timestamp() + "  " + message
+    print message
+    message = message.Replace(Chr(10), " ")
+    currentMessage = m.top.message
+    fullMessage = currentMessage + (Chr(10) + message)
+    lines = m._new_line_regex.Split(fullMessage)
+    maxLines = 3
+    if (lines.Count() > maxLines)
+        fewLines = []
+        for i = (lines.Count() - maxLines) to (lines.Count() - 1)
+            fewLines.Push(lines[i])
+        end for
+        lines = fewLines
+        fullMessage = lines.Join(Chr(10))
+    end if
+
+    m.top.message = currentMessage + (Chr(10) + message)
+end sub

--- a/util/crypto_server/.gitignore
+++ b/util/crypto_server/.gitignore
@@ -1,0 +1,3 @@
+example_client
+rsa_service
+example_client_rsa_service

--- a/util/crypto_server/Makefile
+++ b/util/crypto_server/Makefile
@@ -1,0 +1,10 @@
+.PHONY: all
+
+all: rsa_service
+
+rsa_service: rsa_service.c
+	gcc rsa_service.c -o rsa_service -lmicrohttpd -lssl -lcrypto -ljansson -I/opt/homebrew/include -L/opt/homebrew/lib
+
+
+run-server:
+	openssl s_server -accept 8447 -cert server.cer -cert_chain fullchain.cer -key server.key -tls1_2 -cipher AES256-SHA256 -www -msg -state

--- a/util/crypto_server/README.md
+++ b/util/crypto_server/README.md
@@ -1,0 +1,19 @@
+# rsa_service.c
+RSA Public Key Encryption Web Server written in C
+Dependencies: libmicrohttpd jansson openssl
+- OS X: brew install libmicrohttpd jansson
+- Linux: sudo apt-get install libmicrohttpd-dev libjansson-dev libssl-dev
+
+To build the app type:
+```
+make rsa_service
+```
+
+To start rsa_service as a demon read the respective guide:
+ Linux - README_rsa_service_systemd.md
+ OS X - README_rsa_service_launchd.md
+
+# rsa_server.py
+RSA Public Key Encryption Web Server written in python
+See README_RSA_Server.md
+

--- a/util/crypto_server/README_rsa_server_py.md
+++ b/util/crypto_server/README_rsa_server_py.md
@@ -1,0 +1,326 @@
+# Python RSA Public Key Encryption Web Server
+
+A lightweight web server using Python's built-in http.server module that provides RSA public key encryption services via HTTP REST API. The server accepts hex-encoded data and returns encrypted results using RSA encryption with PKCS1v15 padding.
+
+## Features
+
+- **Certificate Support**: Load public key from X.509 PEM certificate for encrypt-only mode
+- **Private Key Support**: Load private key for full mode (encrypt and decrypt)
+- **Hex Encoding**: Uses hex encoding for data (compatible with C implementation)
+- **Text Encryption**: Encrypt hex-encoded data using RSA public key with PKCS1v15 padding
+- **Text Decryption**: Decrypt encrypted data (only in full mode)
+- **REST API**: Clean JSON-based HTTP API for all operations
+- **Security**: Uses PKCS1v15 padding (compatible with Roku BrightScript)
+- **Error Handling**: Comprehensive error handling and validation
+- **Signal Handling**: Graceful shutdown on SIGTERM/SIGINT
+
+## Quick Start
+
+### Prerequisites
+
+- Python 3.7 or higher
+- pip package manager
+
+### Installation
+
+1. Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+2. Start the server:
+```bash
+# Encrypt-only mode (using certificate)
+python rsa_server.py --certificate server.cer
+
+# Full mode (encrypt and decrypt with private key)
+python rsa_server.py --private-key-pem private.key
+
+# Custom host and port
+python rsa_server.py --host 127.0.0.1 --port 8080 --certificate server.cer
+
+# Bind to specific IP
+python rsa_server.py --host 192.168.1.100 --private-key-pem private.key
+```
+
+The server will start on `http://0.0.0.0:5000` by default.
+
+**Note:** You MUST specify either `--certificate` (encrypt-only) or `--private-key-pem` (full mode). You cannot specify both.
+
+### Basic Usage
+
+**Encrypt hex-encoded data:**
+```bash
+# Data must be hex-encoded string
+curl -X POST http://localhost:5000/encrypt \
+  -H "Content-Type: application/json" \
+  -d '{"data": "48656c6c6f"}'
+```
+
+**Decrypt encrypted data (full mode only):**
+```bash
+curl -X POST http://localhost:5000/decrypt \
+  -H "Content-Type: application/json" \
+  -d '{"encrypted_data": "<hex-encoded-encrypted-data>"}'
+```
+
+**Check server health:**
+```bash
+curl http://localhost:5000/health
+```
+
+## API Documentation
+
+### Endpoints
+
+#### GET `/health`
+Check if the server is running and healthy.
+
+**Response:**
+```json
+{
+  "status": "healthy",
+  "service": "RSA Encryption Server (Native)",
+  "key_size": 2048
+}
+```
+
+#### POST `/encrypt`
+Encrypt hex-encoded data using the server's RSA public key.
+
+**Request Body:**
+```json
+{
+  "data": "48656c6c6f"  // hex-encoded data
+}
+```
+
+**Response:**
+```json
+{
+  "encrypted_data": "a1b2c3d4...",  // hex-encoded encrypted data
+  "original_length": 10,
+  "encrypted_length": 512,
+  "encoding": "hex"
+}
+```
+
+**Error Response (400 - Data too long):**
+```json
+{
+  "error": "Data too long. Maximum length is 245 bytes for 2048-bit key"
+}
+```
+
+#### POST `/decrypt`
+Decrypt RSA encrypted data (only available in full mode with private key).
+
+**Request Body:**
+```json
+{
+  "encrypted_data": "a1b2c3d4..."  // hex-encoded encrypted data
+}
+```
+
+**Response:**
+```json
+{
+  "decrypted_data": "48656c6c6f",  // hex-encoded decrypted data
+  "decrypted_length": 10
+}
+```
+
+**Error Response (403 - Encrypt-only mode):**
+```json
+{
+  "error": "Decryption not available in encrypt-only mode (no private key loaded)"
+}
+```
+
+## Command-Line Options
+
+```
+usage: rsa_server.py [-h] [--host HOST] [--port PORT] [--certificate CERTIFICATE]
+                     [--private-key-pem PRIVATE_KEY_PEM]
+
+RSA Encryption Server
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --host HOST           Host to bind to (default: 0.0.0.0)
+  --port PORT           Port to bind to (default: 5000)
+  --certificate CERTIFICATE
+                        Path to PEM certificate file (encrypt-only mode)
+  --private-key-pem PRIVATE_KEY_PEM
+                        Path to PEM file containing RSA private key (full mode)
+```
+
+## Data Limits
+
+RSA encryption has inherent size limits based on the key size and padding scheme:
+
+| Key Size | Max Plaintext (bytes) |
+|----------|----------------------|
+| 1024-bit | 117 bytes           |
+| 2048-bit | 245 bytes           |
+| 3072-bit | 373 bytes           |
+| 4096-bit | 501 bytes           |
+
+*Limits are for PKCS1v15 padding*
+
+## Security Considerations
+
+- **Padding**: Uses PKCS1v15 padding (compatible with Roku BrightScript implementation)
+- **Private Key**: Kept server-side and never exposed via API (in full mode)
+- **Certificate**: Public key extracted from X.509 certificate (in encrypt-only mode)
+- **Production Use**: For production, consider:
+  - Using HTTPS/TLS for transport encryption
+  - Storing keys securely (HSM, key vault)
+  - Rate limiting and authentication
+  - Logging and monitoring
+  - Firewall rules to restrict access
+
+## Running as a Service
+
+The server can be run as a background service:
+
+**Using nohup:**
+```bash
+nohup python rsa_server.py --certificate server.cer > /var/log/rsa-server.log 2>&1 &
+```
+
+**Stopping the service:**
+```bash
+# Find the process
+ps aux | grep rsa_server.py
+
+# Send SIGTERM for graceful shutdown
+kill -TERM <PID>
+```
+
+## Example Client Code
+
+```python
+import requests
+
+# Initialize client
+base_url = "http://localhost:5000"
+
+# Convert text to hex
+message = "Hello, World!"
+hex_data = message.encode('utf-8').hex()
+
+# Encrypt hex-encoded data
+payload = {"data": hex_data}
+response = requests.post(f"{base_url}/encrypt", json=payload)
+encrypted_result = response.json()
+
+print(f"Encrypted: {encrypted_result['encrypted_data']}")
+
+# Decrypt (only works in full mode with private key)
+decrypt_payload = {"encrypted_data": encrypted_result['encrypted_data']}
+response = requests.post(f"{base_url}/decrypt", json=decrypt_payload)
+decrypted_result = response.json()
+
+# Convert hex back to text
+decrypted_hex = decrypted_result['decrypted_data']
+decrypted_text = bytes.fromhex(decrypted_hex).decode('utf-8')
+
+print(f"Decrypted: {decrypted_text}")
+```
+
+## Command Line Examples
+
+### Using curl
+
+**Encrypt hex-encoded data:**
+```bash
+# Convert text to hex first
+echo -n "Hello" | xxd -p  # Outputs: 48656c6c6f
+
+curl -X POST http://localhost:5000/encrypt \
+  -H "Content-Type: application/json" \
+  -d '{"data": "48656c6c6f"}'
+```
+
+**Decrypt encrypted data:**
+```bash
+curl -X POST http://localhost:5000/decrypt \
+  -H "Content-Type: application/json" \
+  -d '{"encrypted_data": "a1b2c3d4..."}'
+```
+
+**Check health:**
+```bash
+curl http://localhost:5000/health | jq
+```
+
+## Development
+
+### Project Structure
+```
+.
+├── rsa_server.py              # Main server application (Python)
+├── rsa_service.c              # C implementation
+├── requirements.txt           # Python dependencies
+├── README_rsa_server_py.md    # Python server documentation
+└── README.md                  # General documentation
+```
+
+### Testing
+
+Test individual endpoints:
+```bash
+# Test health
+curl http://localhost:5000/health
+
+# Test encryption with hex data
+curl -X POST http://localhost:5000/encrypt \
+  -H "Content-Type: application/json" \
+  -d '{"data": "74657374"}'
+
+# Test decryption (full mode only)
+curl -X POST http://localhost:5000/decrypt \
+  -H "Content-Type: application/json" \
+  -d '{"encrypted_data": "<hex-encrypted-data>"}'
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**Server won't start:**
+- Check if port is available: `lsof -i :5000`
+- Verify Python version (3.7+): `python --version`
+- Install missing dependencies: `pip install -r requirements.txt`
+- Ensure you specified either `--certificate` or `--private-key-pem`
+
+**Encryption fails with "Data too long":**
+- Data must be hex-encoded
+- Check data size limits based on key size (245 bytes for 2048-bit)
+- For larger data, consider hybrid encryption (RSA + AES)
+
+**Invalid hex string error:**
+- Ensure data is properly hex-encoded
+- Use `echo -n "text" | xxd -p` to convert text to hex
+
+**Decryption not available:**
+- Decryption only works in full mode
+- Restart server with `--private-key-pem` instead of `--certificate`
+
+**Client connection errors:**
+- Verify server is running: `curl http://localhost:5000/health`
+- Check firewall settings
+- Ensure correct server URL and port
+
+### Logging
+
+The server logs all requests and errors. Check console output for debugging information.
+
+## License
+
+This project is provided as-is for educational and development purposes.
+
+## Contributing
+
+Feel free to submit issues and enhancement requests!

--- a/util/crypto_server/requirements.txt
+++ b/util/crypto_server/requirements.txt
@@ -1,0 +1,1 @@
+cryptography==41.0.7

--- a/util/crypto_server/rsa_server.py
+++ b/util/crypto_server/rsa_server.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""
+RSA Public Key Encryption Web Server (Native HTTP Server)
+
+A lightweight web server using Python's built-in http.server module
+that provides RSA public key encryption services via HTTP REST API.
+Accepts text data via HTTP requests and returns encrypted results.
+"""
+
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from socketserver import ThreadingMixIn
+from urllib.parse import urlparse, parse_qs
+from cryptography.hazmat.primitives.asymmetric import rsa, padding
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography import x509
+import json
+import base64
+import logging
+import sys
+import os
+from typing import Dict, Any, Optional
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+# Global variables for RSA key pair
+private_key = None
+public_key = None
+
+def load_private_key_from_pem(pem_file_path: str) -> rsa.RSAPrivateKey:
+    """Load RSA private key from PEM file."""
+    try:
+        if not os.path.exists(pem_file_path):
+            raise FileNotFoundError(f"Private key file not found: {pem_file_path}")
+
+        with open(pem_file_path, 'rb') as f:
+            pem_data = f.read()
+
+        private_key = serialization.load_pem_private_key(
+            pem_data,
+            password=None  # Assumes no password protection
+        )
+
+        if not isinstance(private_key, rsa.RSAPrivateKey):
+            raise ValueError(f"File {pem_file_path} does not contain an RSA private key")
+
+        logger.info(f"Loaded RSA private key from {pem_file_path} ({private_key.key_size} bits)")
+        return private_key
+
+    except Exception as e:
+        logger.error(f"Failed to load private key from {pem_file_path}: {e}")
+        raise
+
+
+def load_public_key_from_certificate(cert_file_path: str) -> rsa.RSAPublicKey:
+    """Load RSA public key from PEM certificate file."""
+    try:
+        if not os.path.exists(cert_file_path):
+            raise FileNotFoundError(f"Certificate file not found: {cert_file_path}")
+
+        with open(cert_file_path, 'rb') as f:
+            pem_data = f.read()
+
+        # Load the certificate
+        cert = x509.load_pem_x509_certificate(pem_data)
+        
+        # Extract the public key from the certificate
+        public_key = cert.public_key()
+
+        if not isinstance(public_key, rsa.RSAPublicKey):
+            raise ValueError(f"Certificate {cert_file_path} does not contain an RSA public key")
+
+        logger.info(f"Loaded RSA public key from certificate {cert_file_path} ({public_key.key_size} bits)")
+        return public_key
+
+    except Exception as e:
+        logger.error(f"Failed to load public key from certificate {cert_file_path}: {e}")
+        raise
+
+
+def load_keys_from_files(cert_path: str = None, private_key_path: str = None) -> tuple:
+    """Load RSA keys from certificate or private key PEM files."""
+    global private_key, public_key
+
+    loaded_private_key = None
+    loaded_public_key = None
+
+    # Load private key if provided
+    if private_key_path:
+        loaded_private_key = load_private_key_from_pem(private_key_path)
+        # Extract public key from private key
+        loaded_public_key = loaded_private_key.public_key()
+        logger.info("Derived public key from private key")
+
+    # Load certificate if provided (encrypt-only mode)
+    if cert_path:
+        loaded_public_key = load_public_key_from_certificate(cert_path)
+
+    # Set global variables
+    private_key = loaded_private_key
+    public_key = loaded_public_key
+
+    if private_key and public_key:
+        logger.info(f"Running in FULL mode (encrypt and decrypt) - {public_key.key_size} bits")
+    elif public_key:
+        logger.info(f"Running in ENCRYPT-ONLY mode - {public_key.key_size} bits")
+    else:
+        raise ValueError("No keys loaded. Must specify either --certificate or --private-key-pem")
+
+    return private_key, public_key
+
+
+
+
+def encrypt_data(dataInHexStr: str, pub_key) -> str:
+    """Encrypt dataInHexStr using RSA public key and return hex encoded result."""
+    try:
+        # Decode the hex encoded string into original data bytes
+        data_bytes = bytes.fromhex(dataInHexStr)
+
+        # Encrypt using PKCS1v15 padding (same as C implementation)
+        encrypted = pub_key.encrypt(
+            data_bytes,
+            padding.PKCS1v15()
+        )
+
+        # Return hex encoded encrypted data
+        result = encrypted.hex()
+        logger.info(f"encrypt_data (input: {dataInHexStr}) (output: {result})")
+        return result
+
+    except Exception as e:
+        logger.error(f"Encryption failed: {str(e)}")
+        raise
+
+
+def decrypt_data(encrypted_data: str, priv_key) -> str:
+    """Decrypt hex encoded data using RSA private key."""
+    try:
+        # Decode from hex
+        encrypted_bytes = bytes.fromhex(encrypted_data)
+
+        # Decrypt using PKCS1v15 padding (same as C implementation)
+        decrypted = priv_key.decrypt(
+            encrypted_bytes,
+            padding.PKCS1v15()
+        )
+
+        # Return hex encoded string of the decrypted data
+        result = decrypted.hex()
+        logger.info(f"decrypt_data (input: {encrypted_data}) (output: {result})")
+        return result
+
+    except Exception as e:
+        logger.error(f"Decryption failed: {str(e)}")
+        raise
+
+
+class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+    """Thread per request HTTP Server"""
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+class RSAServerHandler(BaseHTTPRequestHandler):
+    """HTTP request handler for RSA encryption server."""
+
+    def log_message(self, format, *args):
+        """Override to use our logger instead of stderr."""
+        logger.info(f"{self.address_string()} - {format % args}")
+
+    def send_json_response(self, data: Dict[str, Any], status_code: int = 200):
+        """Send JSON response with proper headers."""
+        response_body = json.dumps(data, indent=2).encode('utf-8')
+
+        self.send_response(status_code)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(response_body)))
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type')
+        self.end_headers()
+
+        if self.command != 'HEAD':
+            self.wfile.write(response_body)
+
+    def send_error_response(self, message: str, status_code: int = 400):
+        """Send error response."""
+        self.send_json_response({'error': message}, status_code)
+
+    def get_request_body(self) -> Optional[Dict[str, Any]]:
+        """Parse JSON request body."""
+        try:
+            content_length = int(self.headers.get('Content-Length', 0))
+            if content_length == 0:
+                return {}
+
+            body = self.rfile.read(content_length).decode('utf-8')
+            return json.loads(body)
+        except (ValueError, json.JSONDecodeError) as e:
+            logger.error(f"Failed to parse request body: {e}")
+            return None
+
+    def do_OPTIONS(self):
+        """Handle CORS preflight requests."""
+        self.send_response(200)
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type')
+        self.end_headers()
+
+    def do_GET(self):
+        """Handle GET requests."""
+        parsed_path = urlparse(self.path)
+        path = parsed_path.path
+
+        if path == '/health':
+            self.handle_health()
+        else:
+            self.send_error_response('Endpoint not found', 404)
+
+    def do_POST(self):
+        """Handle POST requests."""
+        parsed_path = urlparse(self.path)
+        path = parsed_path.path
+
+        logger.info(f"do_POST headers: {self.headers}")
+
+
+        if path == '/encrypt':
+            self.handle_encrypt()
+        elif path == '/decrypt':
+            self.handle_decrypt()
+        else:
+            self.send_error_response('Endpoint not found', 404)
+
+    def handle_health(self):
+        """Handle health check endpoint."""
+        # Determine server mode
+        if private_key is not None and public_key is not None:
+            key_mode = 'full' # Both encrypt and decrypt
+        elif public_key is not None:
+            key_mode = 'encrypt-only' # Only encrypt
+        else:
+            key_mode = 'no-keys'
+
+        response = {
+            'status': 'healthy',
+            'service': 'RSA Encryption Server (Native)',
+            'key_size': public_key.key_size if public_key else None
+        }
+        self.send_json_response(response)
+
+
+    def handle_encrypt(self):
+        """Handle text encryption endpoint."""
+        if public_key is None:
+            self.send_error_response('No public key available. Must specify --certificate or --private-key-pem.', 412)
+            return
+
+        # Check content type
+        content_type = self.headers.get('Content-Type', '')
+        if not content_type.startswith('application/json'):
+            self.send_error_response('Content-Type must be application/json', 400)
+            return
+
+        # Parse request body
+        data = self.get_request_body()
+        if data is None:
+            self.send_error_response('Invalid JSON in request body', 400)
+            return
+
+        if 'data' not in data:
+            self.send_error_response('Missing "data" field in request body', 400)
+            return
+
+        text_to_encrypt = data['data']
+        if not isinstance(text_to_encrypt, str):
+            self.send_error_response('"data" field must be a string', 400)
+            return
+
+        # Check data length (RSA has size limits)
+        max_length = (public_key.key_size // 8) - 11  # PKCS1v15 padding overhead
+        try:
+            data_bytes = bytes.fromhex(text_to_encrypt)
+        except ValueError:
+            self.send_error_response('"data" field must be a valid hex string', 400)
+            return
+
+        if len(data_bytes) > max_length:
+            self.send_error_response(
+                f'Data too long. Maximum length is {max_length} bytes for {public_key.key_size}-bit key',
+                400
+            )
+            return
+
+        try:
+            # Encrypt the data
+            encrypted_data = encrypt_data(text_to_encrypt, public_key)
+
+            response = {
+                'encrypted_data': encrypted_data,
+                'original_length': len(text_to_encrypt),
+                'encrypted_length': len(encrypted_data),
+                'encoding': 'hex'
+            }
+            self.send_json_response(response)
+
+        except Exception as e:
+            logger.error(f"Encryption request failed: {str(e)}")
+            self.send_error_response('Encryption failed', 500)
+
+    def handle_decrypt(self):
+        """Handle text decryption endpoint."""
+        if private_key is None:
+            if public_key is not None:
+                self.send_error_response('Decryption not available in encrypt-only mode (no private key loaded)', 403)
+            else:
+                self.send_error_response('No private key available. Must specify --private-key-pem.', 412)
+            return
+
+        # Check content type
+        content_type = self.headers.get('Content-Type', '')
+        if not content_type.startswith('application/json'):
+            self.send_error_response('Content-Type must be application/json', 400)
+            return
+
+        # Parse request body
+        data = self.get_request_body()
+        if data is None:
+            self.send_error_response('Invalid JSON in request body', 400)
+            return
+
+        if 'encrypted_data' not in data:
+            self.send_error_response('Missing "encrypted_data" field in request body', 400)
+            return
+
+        encrypted_data = data['encrypted_data']
+        if not isinstance(encrypted_data, str):
+            self.send_error_response('"encrypted_data" field must be a string', 400)
+            return
+
+        try:
+            # Decrypt the data
+            decrypted_data = decrypt_data(encrypted_data, private_key)
+
+            response = {
+                'decrypted_data': decrypted_data,
+                'decrypted_length': len(decrypted_data)
+            }
+            self.send_json_response(response)
+
+        except Exception as e:
+            errMsg = f"Decryption request failed: {str(e)}"
+            logger.error(errMsg)
+            self.send_error_response(errMsg, 500)
+
+
+
+def run_server(host: str = '0.0.0.0', port: int = 5000):
+    """Run the RSA encryption server."""
+    server_address = (host, port)
+
+    try:
+        httpd = ThreadedHTTPServer(server_address, RSAServerHandler)
+        logger.info(f"RSA Encryption Server starting on http://{host}:{port}")
+        logger.info("Available endpoints:")
+        logger.info("  GET  /health      - Server health check")
+        logger.info("  POST /encrypt     - Encrypt text data")
+        logger.info("  POST /decrypt     - Decrypt encrypted data (if private key loaded)")
+        logger.info("Press Ctrl+C to stop the server")
+
+        httpd.serve_forever()
+
+    except KeyboardInterrupt:
+        logger.info("Server shutdown requested")
+    except Exception as e:
+        logger.error(f"Server error: {e}")
+    finally:
+        if 'httpd' in locals():
+            httpd.server_close()
+        logger.info("Server stopped")
+
+
+def main():
+    """Main function."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='RSA Encryption Server',
+        epilog="""Key loading modes:
+  - Only --certificate: Encrypt-only mode (no decryption)
+  - Only --private-key-pem: Full mode (public key derived from private key)
+  
+Examples:
+  %(prog)s --certificate server.cer --port 8080
+  %(prog)s --host 127.0.0.1 --private-key-pem private.key
+  %(prog)s --host 192.168.1.100 --certificate cert.pem""",
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    parser.add_argument('--host', default='0.0.0.0', help='Host to bind to (default: 0.0.0.0)')
+    parser.add_argument('--port', type=int, default=5000, help='Port to bind to (default: 5000)')
+    parser.add_argument('--certificate', type=str,
+                       help='Path to PEM certificate file (encrypt-only mode)')
+    parser.add_argument('--private-key-pem', type=str,
+                       help='Path to PEM file containing RSA private key (full mode)')
+
+    args = parser.parse_args()
+
+    # Validate arguments
+    if not args.certificate and not args.private_key_pem:
+        parser.error("Must specify either --certificate or --private-key-pem")
+    
+    if args.certificate and args.private_key_pem:
+        parser.error("Cannot specify both --certificate and --private-key-pem")
+
+    try:
+        # Load keys from files
+        logger.info("Loading RSA keys...")
+        load_keys_from_files(args.certificate, args.private_key_pem)
+
+    except Exception as e:
+        logger.error(f"Failed to load keys: {e}")
+        sys.exit(1)
+
+    # Start the server
+    run_server(args.host, args.port)
+
+
+if __name__ == '__main__':
+    main()

--- a/util/crypto_server/rsa_service.c
+++ b/util/crypto_server/rsa_service.c
@@ -1,0 +1,644 @@
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+// For libmicrohttpd
+#include <microhttpd.h>
+
+// For OpenSSL
+#include <openssl/pem.h>
+#include <openssl/rsa.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+#include <openssl/x509.h>
+
+// For Jansson
+#include <jansson.h>
+
+// --- Global Variable ---
+// In a real multi-threaded application, this should be handled with care
+// (e.g., read-only after initialization, or using mutexes if the key could change).
+// For this example, a simple global is sufficient.
+EVP_PKEY *private_key = NULL;
+EVP_PKEY *public_key = NULL;    // Used when running in encrypt-only mode with certificate
+int rsa_key_size_bits = 0;      // Store key size for the health endpoint
+int encrypt_only_mode = 0;      // Flag: 1 if running with certificate (no private key)
+int server_port = 5000;         // Default port, can be changed with --port option
+const char *server_host = NULL; // Host to bind to (NULL = all interfaces)
+
+// Signal handling
+volatile sig_atomic_t keep_running = 1;
+
+// --- Hex String Helper Functions ---
+
+// Encodes a byte array into a newly allocated hex string.
+// The caller is responsible for freeing the returned string.
+char *hex_encode(const unsigned char *input, int length)
+{
+    if (input == NULL || length <= 0)
+        return NULL;
+
+    char *hex_string = malloc(length * 2 + 1);
+    if (hex_string == NULL)
+        return NULL;
+
+    for (int i = 0; i < length; i++)
+    {
+        sprintf(hex_string + (i * 2), "%02x", input[i]);
+    }
+    hex_string[length * 2] = '\0';
+
+    return hex_string;
+}
+
+// Decodes a hex string into a newly allocated byte array.
+// The caller is responsible for freeing the returned buffer.
+unsigned char *hex_decode(const char *input, int *out_len)
+{
+    int len = strlen(input);
+    if (len % 2 != 0)
+    { // Hex strings must have an even number of characters
+        return NULL;
+    }
+
+    *out_len = len / 2;
+    unsigned char *decoded_data = malloc(*out_len);
+    if (decoded_data == NULL)
+        return NULL;
+
+    for (int i = 0; i < *out_len; i++)
+    {
+        char byte_str[3] = {input[i * 2], input[i * 2 + 1], '\0'};
+        if (!isxdigit(byte_str[0]) || !isxdigit(byte_str[1]))
+        {
+            free(decoded_data);
+            return NULL; // Invalid hex character
+        }
+        decoded_data[i] = (unsigned char)strtol(byte_str, NULL, 16);
+    }
+
+    return decoded_data;
+}
+// --- API Logic Functions ---
+
+// Creates a JSON error response string
+char *create_error_response(const char *message)
+{
+    json_t *root = json_object();
+    json_object_set_new(root, "error", json_string(message));
+    char *response_str = json_dumps(root, 0);
+    json_decref(root);
+    return response_str;
+}
+
+// Handles the /health endpoint logic
+enum MHD_Result handle_health(char **response_str, int *http_status)
+{
+    json_t *root = json_object();
+    json_object_set_new(root, "status", json_string("healthy"));
+    json_object_set_new(root, "service", json_string("RSA Encryption Server"));
+    json_object_set_new(root, "key_size", json_integer(rsa_key_size_bits));
+
+    *response_str = json_dumps(root, JSON_INDENT(2)); // Pretty-print the JSON
+    json_decref(root);
+
+    *http_status = MHD_HTTP_OK;
+    return MHD_YES;
+}
+
+// Handles the /encrypt endpoint logic
+enum MHD_Result handle_encrypt(const char *post_data, char **response_str, int *http_status)
+{
+    json_error_t error;
+    json_t *root = json_loads(post_data, 0, &error);
+    if (!root)
+    {
+        *response_str = create_error_response("Invalid JSON format.");
+        *http_status = MHD_HTTP_BAD_REQUEST;
+        return MHD_YES;
+    }
+
+    json_t *data_node = json_object_get(root, "data");
+    if (!json_is_string(data_node))
+    {
+        *response_str = create_error_response("Missing or invalid 'data' field in JSON.");
+        *http_status = MHD_HTTP_BAD_REQUEST;
+        json_decref(root);
+        return MHD_YES;
+    }
+
+    const char *hex_input = json_string_value(data_node);
+    int decoded_len = 0;
+    unsigned char *decoded_data = hex_decode(hex_input, &decoded_len);
+
+    if (!decoded_data)
+    {
+        json_decref(root);
+        *response_str = create_error_response("Invalid Hex data.");
+        *http_status = MHD_HTTP_BAD_REQUEST;
+        return MHD_YES;
+    }
+
+    // Perform RSA Public Key Encryption
+    // Use public_key in encrypt-only mode, otherwise extract from private_key
+    EVP_PKEY *key_for_encryption = encrypt_only_mode ? public_key : private_key;
+    RSA *rsa = EVP_PKEY_get1_RSA(key_for_encryption);
+    int rsa_size = RSA_size(rsa);
+    unsigned char *encrypted_data = malloc(rsa_size);
+
+    int encrypted_len = RSA_public_encrypt(decoded_len, decoded_data, encrypted_data, rsa, RSA_PKCS1_PADDING);
+    free(decoded_data);
+    RSA_free(rsa);
+
+    if (encrypted_len == -1)
+    {
+        *response_str = create_error_response("RSA encryption failed.");
+        *http_status = MHD_HTTP_INTERNAL_SERVER_ERROR;
+        free(encrypted_data);
+        json_decref(root);
+        return MHD_YES;
+    }
+
+    // Hex encode the result and create the JSON response
+    char *hex_output = hex_encode(encrypted_data, encrypted_len);
+    free(encrypted_data);
+
+    printf("encrypt_data (input: %s) (output: %s)\n", hex_input, hex_output);
+    json_decref(root);
+
+    json_t *response_json = json_object();
+    json_object_set_new(response_json, "encrypted_data", json_string(hex_output));
+    json_object_set_new(response_json, "original_length", json_integer(decoded_len));
+    json_object_set_new(response_json, "encrypted_length", json_integer(encrypted_len));
+    *response_str = json_dumps(response_json, 0);
+    free(hex_output);
+    json_decref(response_json);
+    *http_status = MHD_HTTP_OK;
+
+    return MHD_YES;
+}
+
+// Handles the /decrypt endpoint logic
+enum MHD_Result handle_decrypt(const char *post_data, char **response_str, int *http_status)
+{
+    // Check if running in encrypt-only mode
+    if (encrypt_only_mode)
+    {
+        *response_str = create_error_response("Decryption not available in encrypt-only mode (no private key loaded)");
+        *http_status = MHD_HTTP_FORBIDDEN;
+        return MHD_YES;
+    }
+
+    json_error_t error;
+    json_t *root = json_loads(post_data, 0, &error);
+    if (!root)
+    {
+        *response_str = create_error_response("Invalid JSON format.");
+        *http_status = MHD_HTTP_BAD_REQUEST;
+        return MHD_YES;
+    }
+
+    json_t *data_node = json_object_get(root, "encrypted_data");
+    if (!json_is_string(data_node))
+    {
+        *response_str = create_error_response("Missing or invalid 'encrypted_data' field in JSON.");
+        *http_status = MHD_HTTP_BAD_REQUEST;
+        json_decref(root);
+        return MHD_YES;
+    }
+
+    const char *hex_input = json_string_value(data_node);
+    int decoded_len = 0;
+    unsigned char *decoded_data = hex_decode(hex_input, &decoded_len);
+
+    if (!decoded_data)
+    {
+        json_decref(root);
+        *response_str = create_error_response("Invalid Hex data.");
+        *http_status = MHD_HTTP_BAD_REQUEST;
+        return MHD_YES;
+    }
+
+    // Perform RSA Private Key Decryption
+    RSA *rsa = EVP_PKEY_get1_RSA(private_key);
+    int rsa_size = RSA_size(rsa);
+    unsigned char *decrypted_data = malloc(rsa_size * 2);
+
+    int decrypted_len = RSA_private_decrypt(decoded_len, decoded_data, decrypted_data, rsa, RSA_PKCS1_PADDING);
+    free(decoded_data);
+    RSA_free(rsa);
+
+    if (decrypted_len == -1)
+    {
+        *response_str = create_error_response("RSA decryption failed. Data might be invalid.");
+        fprintf(stderr, "ERROR: %s hex_input: %s\n", *response_str, hex_input);
+        ERR_print_errors_fp(stderr);
+        json_decref(root);
+        *http_status = MHD_HTTP_BAD_REQUEST; // Treat as a client error
+        free(decrypted_data);
+        return MHD_YES;
+    }
+
+    // Hex encode the result and create JSON response
+    char *hex_output = hex_encode(decrypted_data, decrypted_len);
+    printf("decrypt_data (input: %s) (output: %s)\n", hex_input, hex_output);
+    json_decref(root);
+    free(decrypted_data);
+
+    json_t *response_json = json_object();
+    json_object_set_new(response_json, "decrypted_data", json_string(hex_output));
+
+    *response_str = json_dumps(response_json, 0);
+    free(hex_output);
+    json_decref(response_json);
+    *http_status = MHD_HTTP_OK;
+
+    return MHD_YES;
+}
+
+// --- Signal Handler ---
+
+void signal_handler(int signum)
+{
+    if (signum == SIGTERM || signum == SIGINT)
+    {
+        printf("\nReceived signal %d, shutting down gracefully...\n", signum);
+        keep_running = 0;
+    }
+}
+
+// --- HTTP Server (libmicrohttpd) Callback ---
+
+enum MHD_Result answer_to_connection(void *cls, struct MHD_Connection *connection,
+                                     const char *url, const char *method,
+                                     const char *version, const char *upload_data,
+                                     size_t *upload_data_size, void **con_cls)
+{
+
+    char *response_str = NULL;
+    int http_status = MHD_HTTP_NOT_FOUND;
+
+    // --- Routing ---
+    if (0 == strcmp(url, "/health") && 0 == strcmp(method, "GET"))
+    {
+        handle_health(&response_str, &http_status);
+    }
+    else if (0 == strcmp(method, "POST"))
+    {
+        // Handle POST requests, which require a body
+        if (NULL == *con_cls)
+        {
+            char *post_buffer = malloc(1);
+            post_buffer[0] = '\0';
+            *con_cls = post_buffer;
+            return MHD_YES;
+        }
+
+        if (*upload_data_size != 0)
+        {
+            char *post_buffer = *con_cls;
+            size_t current_size = strlen(post_buffer);
+            post_buffer = realloc(post_buffer, current_size + *upload_data_size + 1);
+            if (!post_buffer)
+                return MHD_NO;
+
+            memcpy(post_buffer + current_size, upload_data, *upload_data_size);
+            post_buffer[current_size + *upload_data_size] = '\0';
+            *con_cls = post_buffer;
+            *upload_data_size = 0;
+            return MHD_YES;
+        }
+
+        // Full POST body received
+        char *post_body = *con_cls;
+        if (0 == strcmp(url, "/encrypt"))
+        {
+            handle_encrypt(post_body, &response_str, &http_status);
+        }
+        else if (0 == strcmp(url, "/decrypt"))
+        {
+            handle_decrypt(post_body, &response_str, &http_status);
+        }
+        else
+        {
+            response_str = create_error_response("Endpoint not found for POST method.");
+        }
+
+        // Cleanup POST buffer
+        free(post_body);
+        *con_cls = NULL;
+    }
+    else
+    {
+        // Any other method/URL combo
+        response_str = create_error_response("Method not allowed or endpoint not found.");
+        http_status = MHD_HTTP_METHOD_NOT_ALLOWED;
+    }
+
+    struct MHD_Response *response = MHD_create_response_from_buffer(strlen(response_str),
+                                                                    (void *)response_str,
+                                                                    MHD_RESPMEM_MUST_FREE);
+    MHD_add_response_header(response, "Content-Type", "application/json");
+
+    enum MHD_Result ret = MHD_queue_response(connection, http_status, response);
+    MHD_destroy_response(response);
+
+    return ret;
+}
+
+// --- Main Entry Point ---
+
+int main(int argc, char *argv[])
+{
+    // Parse command line arguments in any order
+    if (argc < 2)
+    {
+        fprintf(stderr, "Usage: %s [OPTIONS]\n", argv[0]);
+        fprintf(stderr, "\n");
+        fprintf(stderr, "Required (one of):\n");
+        fprintf(stderr, "  --private-key-pem FILE    Use private key (enables both encrypt and decrypt)\n");
+        fprintf(stderr, "  --certificate FILE        Use certificate (encrypt-only mode)\n");
+        fprintf(stderr, "\n");
+        fprintf(stderr, "Optional:\n");
+        fprintf(stderr, "  --host HOST               Host/IP to bind to (default: 0.0.0.0 - all interfaces)\n");
+        fprintf(stderr, "  --port PORT               TCP port to listen on (default: 5000)\n");
+        fprintf(stderr, "\n");
+        fprintf(stderr, "Examples:\n");
+        fprintf(stderr, "  %s --certificate cert.pem --port 8080\n", argv[0]);
+        fprintf(stderr, "  %s --host 127.0.0.1 --port 3000 --private-key-pem private.key\n", argv[0]);
+        fprintf(stderr, "  %s --host 192.168.1.100 --certificate cert.pem\n", argv[0]);
+        return 1;
+    }
+
+    // Variables to store parsed options
+    const char *key_file_path = NULL;
+    const char *cert_file_path = NULL;
+    int port_specified = 0;
+    int host_specified = 0;
+
+    // Parse all arguments
+    for (int i = 1; i < argc; i++)
+    {
+        if (strcmp(argv[i], "--private-key-pem") == 0)
+        {
+            if (i + 1 >= argc)
+            {
+                fprintf(stderr, "Error: --private-key-pem requires a file path\n");
+                return 1;
+            }
+            if (key_file_path != NULL)
+            {
+                fprintf(stderr, "Error: --private-key-pem specified multiple times\n");
+                return 1;
+            }
+            if (cert_file_path != NULL)
+            {
+                fprintf(stderr, "Error: Cannot specify both --private-key-pem and --certificate\n");
+                return 1;
+            }
+            key_file_path = argv[i + 1];
+            i++; // Skip the file path in next iteration
+        }
+        else if (strcmp(argv[i], "--certificate") == 0)
+        {
+            if (i + 1 >= argc)
+            {
+                fprintf(stderr, "Error: --certificate requires a file path\n");
+                return 1;
+            }
+            if (cert_file_path != NULL)
+            {
+                fprintf(stderr, "Error: --certificate specified multiple times\n");
+                return 1;
+            }
+            if (key_file_path != NULL)
+            {
+                fprintf(stderr, "Error: Cannot specify both --private-key-pem and --certificate\n");
+                return 1;
+            }
+            cert_file_path = argv[i + 1];
+            i++; // Skip the file path in next iteration
+        }
+        else if (strcmp(argv[i], "--port") == 0)
+        {
+            if (i + 1 >= argc)
+            {
+                fprintf(stderr, "Error: --port requires a port number\n");
+                return 1;
+            }
+            if (port_specified)
+            {
+                fprintf(stderr, "Error: --port specified multiple times\n");
+                return 1;
+            }
+
+            char *endptr;
+            long port_long = strtol(argv[i + 1], &endptr, 10);
+
+            if (*endptr != '\0' || port_long < 1 || port_long > 65535)
+            {
+                fprintf(stderr, "Error: Invalid port number '%s'. Must be between 1 and 65535.\n", argv[i + 1]);
+                return 1;
+            }
+
+            server_port = (int)port_long;
+            port_specified = 1;
+            i++; // Skip the port value in next iteration
+        }
+        else if (strcmp(argv[i], "--host") == 0)
+        {
+            if (i + 1 >= argc)
+            {
+                fprintf(stderr, "Error: --host requires a hostname or IP address\n");
+                return 1;
+            }
+            if (host_specified)
+            {
+                fprintf(stderr, "Error: --host specified multiple times\n");
+                return 1;
+            }
+
+            server_host = argv[i + 1];
+            host_specified = 1;
+            i++; // Skip the host value in next iteration
+        }
+        else
+        {
+            fprintf(stderr, "Error: Unknown option '%s'\n", argv[i]);
+            fprintf(stderr, "Use '%s' without arguments to see usage information\n", argv[0]);
+            return 1;
+        }
+    }
+
+    // Validate that exactly one of --private-key-pem or --certificate was provided
+    if (key_file_path == NULL && cert_file_path == NULL)
+    {
+        fprintf(stderr, "Error: Must specify either --private-key-pem or --certificate\n");
+        fprintf(stderr, "Use '%s' without arguments to see usage information\n", argv[0]);
+        return 1;
+    }
+
+    // Load the key or certificate
+    if (cert_file_path != NULL)
+    {
+        // Load certificate and extract public key
+        FILE *cert_file = fopen(cert_file_path, "r");
+        if (!cert_file)
+        {
+            perror("Failed to open certificate file");
+            return 1;
+        }
+
+        X509 *cert = PEM_read_X509(cert_file, NULL, NULL, NULL);
+        fclose(cert_file);
+
+        if (!cert)
+        {
+            fprintf(stderr, "Failed to read certificate from %s\n", cert_file_path);
+            ERR_print_errors_fp(stderr);
+            return 1;
+        }
+
+        public_key = X509_get_pubkey(cert);
+        X509_free(cert);
+
+        if (!public_key)
+        {
+            fprintf(stderr, "Failed to extract public key from certificate %s\n", cert_file_path);
+            ERR_print_errors_fp(stderr);
+            return 1;
+        }
+
+        rsa_key_size_bits = EVP_PKEY_bits(public_key);
+        encrypt_only_mode = 1;
+        printf("Loaded public key from certificate %s (%d bits)\n", cert_file_path, rsa_key_size_bits);
+        printf("Running in ENCRYPT-ONLY mode\n");
+    }
+    else // key_file_path != NULL
+    {
+        FILE *key_file = fopen(key_file_path, "r");
+        if (!key_file)
+        {
+            perror("Failed to open private key file");
+            return 1;
+        }
+
+        private_key = PEM_read_PrivateKey(key_file, NULL, NULL, NULL);
+        fclose(key_file);
+
+        if (!private_key)
+        {
+            fprintf(stderr, "Failed to read private key from %s\n", key_file_path);
+            ERR_print_errors_fp(stderr);
+            return 1;
+        }
+
+        rsa_key_size_bits = EVP_PKEY_bits(private_key);
+        encrypt_only_mode = 0;
+        printf("Loaded private key from %s (%d bits)\n", key_file_path, rsa_key_size_bits);
+        printf("Running in FULL mode (encrypt and decrypt)\n");
+    }
+
+    // Set up signal handlers for graceful shutdown
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = signal_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+
+    if (sigaction(SIGTERM, &sa, NULL) == -1)
+    {
+        perror("Failed to set up SIGTERM handler");
+        if (private_key)
+            EVP_PKEY_free(private_key);
+        if (public_key)
+            EVP_PKEY_free(public_key);
+        return 1;
+    }
+
+    if (sigaction(SIGINT, &sa, NULL) == -1)
+    {
+        perror("Failed to set up SIGINT handler");
+        if (private_key)
+            EVP_PKEY_free(private_key);
+        if (public_key)
+            EVP_PKEY_free(public_key);
+        return 1;
+    }
+
+    // Prepare socket address if specific host is requested
+    struct sockaddr_in addr;
+    struct MHD_Daemon *daemon;
+
+    if (server_host != NULL)
+    {
+        // Bind to specific address
+        memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_port = htons(server_port);
+
+        if (inet_pton(AF_INET, server_host, &addr.sin_addr) != 1)
+        {
+            fprintf(stderr, "Error: Invalid IP address '%s'\n", server_host);
+            if (private_key)
+                EVP_PKEY_free(private_key);
+            if (public_key)
+                EVP_PKEY_free(public_key);
+            return 1;
+        }
+
+        daemon = MHD_start_daemon(MHD_USE_SELECT_INTERNALLY, server_port, NULL, NULL,
+                                  &answer_to_connection, NULL,
+                                  MHD_OPTION_SOCK_ADDR, (struct sockaddr *)&addr,
+                                  MHD_OPTION_END);
+    }
+    else
+    {
+        // Bind to all interfaces (default)
+        daemon = MHD_start_daemon(MHD_USE_SELECT_INTERNALLY, server_port, NULL, NULL,
+                                  &answer_to_connection, NULL, MHD_OPTION_END);
+    }
+
+    if (NULL == daemon)
+    {
+        fprintf(stderr, "Failed to start HTTP server daemon on %s:%d.\n",
+                server_host ? server_host : "0.0.0.0", server_port);
+        if (private_key)
+            EVP_PKEY_free(private_key);
+        if (public_key)
+            EVP_PKEY_free(public_key);
+        return 1;
+    }
+
+    printf("RSA service started on %s:%d (PID: %d)\n",
+           server_host ? server_host : "0.0.0.0", server_port, getpid());
+    if (encrypt_only_mode)
+    {
+        printf("Endpoints available: POST /encrypt (decrypt disabled in encrypt-only mode)\n");
+    }
+    else
+    {
+        printf("Endpoints available: POST /encrypt, POST /decrypt\n");
+    }
+    printf("Server running. Send SIGTERM or SIGINT to stop gracefully.\n");
+
+    // Main loop - wait for signal
+    while (keep_running)
+    {
+        sleep(1);
+    }
+
+    printf("Stopping server...\n");
+    MHD_stop_daemon(daemon);
+    if (private_key)
+        EVP_PKEY_free(private_key);
+    if (public_key)
+        EVP_PKEY_free(public_key);
+
+    return 0;
+}

--- a/util/echo/readme.md
+++ b/util/echo/readme.md
@@ -7,6 +7,17 @@ Tiny node script to create a websocket echo server
 Install the node "ws" library
 
 1. `npm install` from the echo folder root
-2. `node websocket_echo_server.js`
 
-The server is started on port 5000 and echos both binary and text frames.
+Run plain WebSocket server
+
+   `node websocket_echo_server.js`
+
+    The plain WebSocket server is started on port 5000.
+
+Run secure WebSocket server
+
+    `node websocket_echo_server_ssl.js server.key server.cer [PORT]`
+
+    Default port for secure WebSocket server is 5001.
+
+The WebSocket servers echo both binary and text frames.

--- a/util/echo/websocket_echo_server_ssl.js
+++ b/util/echo/websocket_echo_server_ssl.js
@@ -1,0 +1,63 @@
+const fs = require("fs");
+const https = require("https");
+const WebSocketServer = require("ws").Server;
+
+// process.argv mapping:
+// 2: key path, 3: cert path, 4: port
+const keyPath = process.argv[2];
+const certPath = process.argv[3];
+const port = process.argv[4] || 5001; // Default to 5001 if not provided
+
+// Basic error checking for required arguments
+if (!keyPath || !certPath) {
+    console.error("Usage: node script.js <key-file> <cert-file> [port]");
+    console.error("Example: node script.js key.pem cert.pem 8443");
+    process.exit(1);
+}
+
+try {
+    const serverConfig = {
+        key: fs.readFileSync(keyPath),
+        cert: fs.readFileSync(certPath)
+    };
+
+    // 1. Create the HTTPS server
+    const httpsServer = https.createServer(serverConfig, (req, res) => {
+        res.writeHead(200);
+        res.end("WSS server is running\n");
+    });
+
+    // 2. Attach WebSocket server
+    const wss = new WebSocketServer({ server: httpsServer });
+
+    wss.on("connection", function (socket) {
+        console.log("Client connected");
+
+        socket.on("message", function (message) {
+            // Convert buffer to string for logging
+            console.log("Received: " + message.toString());
+            socket.send(message);
+        });
+
+        socket.on("error", function (error) {
+            console.error("Socket Error: ", error);
+        });
+
+        socket.on("close", () => console.log("Client disconnected"));
+    });
+
+    // 3. Start the server
+    httpsServer.listen(port, () => {
+        console.log(`-----------------------------------------------`);
+        console.log(`Secure WebSocket Server (WSS) started`);
+        console.log(`Port: ${port}`);
+        console.log(`Key:  ${keyPath}`);
+        console.log(`Cert: ${certPath}`);
+        console.log(`-----------------------------------------------`);
+    });
+
+} catch (err) {
+    console.error("Error starting server:");
+    console.error(err.message);
+    process.exit(1);
+}


### PR DESCRIPTION
Allow WebSocketClient to connect to Secure WebSocket server offering cipher TLS_RSA_WITH_AES_256_CBC_SHA256.

The TLS 1.2 handshake is implemented with the help of external RSA service which encrypts the client pre-master secret with the server's public key. This assymetric encryption function is not available on the Roku platform. After this step all other steps in this cipher suite involve only symmteric encryption, which is natively available on the Roku platform.

Implementation of the RSA service is availble in Python and C in the files:
 -   util/crypto_server/rsa_server.py
 -   util/crypto_server/rsa_service.c

Most modern HTTPS servers will not allow handshake with this cipher but implementing a newer cipher, like TLS 1.2 ECDHE-ECDSA-AES256-GCM-SHA384 or TLS 1.3 ciphers, requires third party service for every send or read operation which renders the WebSocket functionallity useless, so this is the best that can be done until Roku releases the roWebSocket component.